### PR TITLE
Allow installation with Composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,25 @@ The library itself has no external dependencies. Although if you want to run tes
 
 `phpunit --bootstrap src/autoload.php tests/tests.php`
 
+Installation
+------------
+
+### Standalone
+
+Just copy the files to your project, and include the `src/autoload.php` file.
+
+### Using Composer
+
+Define the following requirement in your `composer.json` file:
+
+    {
+        "require": {
+            "imgix/imgix-php": "dev-master"
+        }
+    }
+
+And include the global `vendor/autoload.php` autoloader.
+
 Basic Usage
 -----------
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+  "name": "imgix/imgix-php",
+  "description": "A PHP client library for generating URLs with imgix.",
+  "type": "library",
+  "keywords": [
+    "imgix"
+  ],
+  "require": {
+    "php": ">=5.3"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "*"
+  },
+  "autoload": {
+    "psr-0": {
+      "Imgix\\": "src/"
+    }
+  }
+}


### PR DESCRIPTION
PHP libraries have a de-facto standard package manager: [Composer](https://getcomposer.org/).

Adding a `composer.json` file and registering the imgix-php library with [Packagist](https://packagist.org/), the central Composer repository, allows PHP projects to automatically install the library and keep it up-to-date as new versions are released.

Moreover, Composer provides its own class autoloading mechanism for all managed libraries. I added notes about this in the README.

Once the composer.json is included in your repository, you will need to submit the package to Packagist:
https://packagist.org/packages/submit

Using the repository URL:
https://github.com/imgix/imgix-php.git

You will need to create an account on Packagist first.

Thank you for providing a PHP library, Composer support will be the icing on the cake!
