### PR TITLE
UrlBuilder does not CGI-encode fully-qualified URLs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "imgix"
   ],
   "require": {
-    "php": ">=5.3"
+    "php": ">=5.3",
+    "jakeasmith/http_build_url": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,45 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "63e826441987c24766a36dfa52c7e0e3",
-    "packages": [],
+    "hash": "7441d910eae3b22d63087429d01de669",
+    "packages": [
+        {
+            "name": "jakeasmith/http_build_url",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jakeasmith/http_build_url.git",
+                "reference": "15bdd686e5178ddfa3e88de60fa585adffb292bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jakeasmith/http_build_url/zipball/15bdd686e5178ddfa3e88de60fa585adffb292bb",
+                "reference": "15bdd686e5178ddfa3e88de60fa585adffb292bb",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~3.7"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/http_build_url.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jake A. Smith",
+                    "email": "theman@jakeasmith.com"
+                }
+            ],
+            "description": "Provides functionality for http_build_url() to environments without pecl_http.",
+            "time": "2015-05-06 12:27:20"
+        }
+    ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",

--- a/src/Imgix/UrlHelper.php
+++ b/src/Imgix/UrlHelper.php
@@ -55,7 +55,7 @@ class UrlHelper {
 
         $url_parts = array('scheme' => $this->scheme, 'host' => $this->domain, 'path' => $this->path, 'query' => $query);
 
-        return self::join_url($url_parts);
+        return self::joinURL($url_parts);
     }
 
     public static function encodeURIComponent($str) {
@@ -63,47 +63,13 @@ class UrlHelper {
         return strtr(rawurlencode($str), $revert);
     }
 
-    // TODO: This is almost entirely garbage. We should not be manually building URLs
-    public static function join_url($parts, $encode=true) {
-        $url = '';
-        if (!empty($parts['scheme'])) {
-            $url .= $parts['scheme'] . ':';
-        }
-        if (isset($parts['host'])) {
-            $url .= '//';
-            if (isset($parts['user'])) {
-                $url .= $parts['user'];
-                if (isset($parts['pass']))
-                    $url .= ':' . $parts['pass'];
-                $url .= '@';
-            }
-            if (preg_match('!^[\da-f]*:[\da-f.:]+$!ui', $parts['host'])) {
-                $url .= '[' . $parts['host'] . ']';
-            } else {
-                $url .= $parts['host'];
-            }
-            if (isset($parts['port'])) {
-                $url .= ':' . $parts['port'];
-            }
-            if (!empty($parts['path']) && $parts['path'][0] != '/') {
-                $url .= '/';
-            }
-        }
-        if (!empty($parts['path'])) {
-            $url .= $parts['path'];
-        }
-        if (isset($parts['query']) && strlen($parts['query']) > 0) {
-            if (substr($parts['query'], 0, 2) === "s=") {
-                $url .= '?&' . $parts['query']; // imgix idiosyncracy for signing URLs when only the signature exists. Our query string must begin with '?&s='
-            } else {
-                $url .= '?' . $parts['query'];
-            }
-        }
-        if (isset($parts['fragment'])) {
-            $url .= '#' . $parts['fragment'];
+    public static function joinURL($parts) {
+
+        // imgix idiosyncracy for signing URLs when only the signature exists. Our query string must begin with '?&s='
+        if (substr($parts['query'], 0, 2) === "s=") {
+            $parts['query'] = "&" . $parts['query'];
         }
 
-        return $url;
+        return http_build_url($parts);
     }
-
 }

--- a/tests/Imgix/Tests/UrlBuilderTest.php
+++ b/tests/Imgix/Tests/UrlBuilderTest.php
@@ -39,7 +39,7 @@ class UrlBuilderTest extends PHPUnit_Framework_TestCase {
         $params = array("w" => 100, "h" => 100);
         $url = $builder->createURL("bridge.png", $params);
 
-        $this->assertEquals($url, "http://demos.imgix.net/bridge.png?h=100&w=100");
+        $this->assertEquals("http://demos.imgix.net/bridge.png?h=100&w=100", $url);
     }
 
     public function testExamplePlainHttps() {
@@ -49,7 +49,7 @@ class UrlBuilderTest extends PHPUnit_Framework_TestCase {
         $params = array("w" => 100, "h" => 100);
         $url = $builder->createURL("bridge.png", $params);
 
-        $this->assertEquals($url, "https://demos.imgix.net/bridge.png?h=100&w=100");
+        $this->assertEquals("https://demos.imgix.net/bridge.png?h=100&w=100", $url);
     }
 
     public function testExamplePlainSecure() {
@@ -58,7 +58,31 @@ class UrlBuilderTest extends PHPUnit_Framework_TestCase {
         $params = array("w" => 100, "h" => 100);
         $url = $builder->createURL("bridge.png", $params);
 
-        $this->assertEquals($url, "http://demos.imgix.net/bridge.png?h=100&w=100&s=bb8f3a2ab832e35997456823272103a4");
+        $this->assertEquals("http://demos.imgix.net/bridge.png?h=100&w=100&s=bb8f3a2ab832e35997456823272103a4", $url);
+    }
+
+    public function testWithFullyQualifiedUrl() {
+        $builder = new UrlBuilder("demos.imgix.net", true);
+        $builder->setSignKey("test1234");
+        $url = $builder->createUrl("http://media.giphy.com/media/jCMq0p94fgBIk/giphy.gif");
+
+        $this->assertEquals("https://demos.imgix.net/http%3A%2F%2Fmedia.giphy.com%2Fmedia%2FjCMq0p94fgBIk%2Fgiphy.gif?&s=ffc3359566fe1dc6445ad17d17b98951", $url);
+    }
+
+    public function testWithFullyQualifiedUrlWithSpaces() {
+        $builder = new UrlBuilder("demos.imgix.net", true);
+        $builder->setSignKey("test1234");
+        $url = $builder->createUrl("https://my-demo-site.com/files/133467012/avatar icon.png");
+
+        $this->assertEquals("https://demos.imgix.net/https%3A%2F%2Fmy-demo-site.com%2Ffiles%2F133467012%2Favatar+icon.png?&s=f6a4e1504af365564014564f1d7e13de", $url);
+    }
+
+    public function testWithFullyQualifiedUrlWithParams() {
+        $builder = new UrlBuilder("demos.imgix.net", true);
+        $builder->setSignKey("test1234");
+        $url = $builder->createUrl("https://my-demo-site.com/files/133467012/avatar icon.png?some=chill&params=1");
+
+        $this->assertEquals("https://demos.imgix.net/https%3A%2F%2Fmy-demo-site.com%2Ffiles%2F133467012%2Favatar+icon.png%3Fsome%3Dchill%26params%3D1?&s=259b9ca6206721752ad7a3ce50f08dd2", $url);
     }
   }
 ?>

--- a/tests/Imgix/Tests/UrlHelperTest.php
+++ b/tests/Imgix/Tests/UrlHelperTest.php
@@ -8,26 +8,26 @@ class UrlHelperTest extends PHPUnit_Framework_TestCase {
         $params = array("w" => 500);
         $uh = new URLHelper("securejackangers.imgix.net", "chester.png", "http", "Q61NvXIy", $params);
 
-        $this->assertEquals($uh->getURL(), "http://securejackangers.imgix.net/chester.png?w=500&s=0ddf97bf1a266a1da6c30c6ce327f917");
+        $this->assertEquals("http://securejackangers.imgix.net/chester.png?w=500&s=0ddf97bf1a266a1da6c30c6ce327f917", $uh->getURL());
     }
 
     public function testHelperBuildSignedURLWithHashMapAndNoParams() {
         $params = array();
         $uh = new URLHelper("securejackangers.imgix.net", "chester.png", "http", "Q61NvXIy", $params);
 
-        $this->assertEquals($uh->getURL(), "http://securejackangers.imgix.net/chester.png?s=cff7bdfd1b32d82e6b516f7fd3b4f1f4");
+        $this->assertEquals("http://securejackangers.imgix.net/chester.png?&s=711dfe95b041008a3c6f460a40052282", $uh->getURL());
     }
 
     public function testHelperBuildSignedURLWithHashSetterParams() {
         $uh = new URLHelper("securejackangers.imgix.net", "chester.png", "http", "Q61NvXIy");
         $uh->setParameter("w", 500);
-        $this->assertEquals($uh->getURL(), "http://securejackangers.imgix.net/chester.png?w=500&s=0ddf97bf1a266a1da6c30c6ce327f917");
+        $this->assertEquals("http://securejackangers.imgix.net/chester.png?w=500&s=0ddf97bf1a266a1da6c30c6ce327f917", $uh->getURL());
     }
 
     public function testHelperBuildSignedURLWithHashSetterParamsHttps() {
         $uh = new URLHelper("securejackangers.imgix.net", "chester.png", "https", "Q61NvXIy");
         $uh->setParameter("w", 500);
-        $this->assertEquals($uh->getURL(), "https://securejackangers.imgix.net/chester.png?w=500&s=0ddf97bf1a266a1da6c30c6ce327f917");
+        $this->assertEquals("https://securejackangers.imgix.net/chester.png?w=500&s=0ddf97bf1a266a1da6c30c6ce327f917", $uh->getURL());
     }
 }
 


### PR DESCRIPTION
This will cause problems when trying to encode URLs with query parameters. Similar issues have cropped up in other imgix libraries, like imgix-rb: https://github.com/imgix/imgix-rb/commit/bf1e5966780dd111e244c168146dc15e1b2b25e4