### PR TITLE
Update UrlHelper.php

### DIFF
--- a/src/Imgix/UrlHelper.php
+++ b/src/Imgix/UrlHelper.php
@@ -34,10 +34,14 @@ class UrlHelper {
     }
 
     public function getURL() {
-        ksort($this->params);
         $queryPairs = array();
-        foreach ($this->params as $k => $v) {
-            $queryPairs[] = $k . "=" . self::encodeURIComponent($v);
+        
+        if ($this->params) {
+            ksort($this->params);
+            
+            foreach ($this->params as $k => $v) {
+                $queryPairs[] = $k . "=" . self::encodeURIComponent($v);
+            }
         }
 
         $query = join("&", $queryPairs);


### PR DESCRIPTION
Prevent warning for "ksort() expects parameter 1 to be array" if an empty $params array is passed.