### PR TITLE
Return the url and avoid the temp variable

### DIFF
--- a/src/Imgix/UrlHelper.php
+++ b/src/Imgix/UrlHelper.php
@@ -103,8 +103,6 @@ class UrlHelper {
     }
 
     private static function joinURL($parts) {
-        $url = $parts['scheme'] . '://' . $parts['host'] . $parts['path'] . $parts['query'];
-
-        return $url;
+        return $parts['scheme'] . '://' . $parts['host'] . $parts['path'] . $parts['query'];
     }
 }


### PR DESCRIPTION
Since no checks of array values with isset or so and just normal concatenation