### PR TITLE
Adding rawEncodePath parameter to createURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ distributed image processing service. More information can be found at
 The tests have a few external dependencies. To install those:
 
 ```bash
-phpunit --bootstrap src/autoload.php tests/tests.php
+phpunit --bootstrap src/autoload.php tests/
 ```
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "imgix/imgix-php",
   "description": "A PHP client library for generating URLs with imgix.",
   "type": "library",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "keywords": [
     "imgix"
   ],

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "imgix/imgix-php",
   "description": "A PHP client library for generating URLs with imgix.",
   "type": "library",
-  "version": "1.1.1",
+  "version": "1.1.0",
   "keywords": [
     "imgix"
   ],

--- a/src/Imgix/UrlBuilder.php
+++ b/src/Imgix/UrlBuilder.php
@@ -66,6 +66,6 @@ class UrlBuilder {
     // force unsigned int since 32-bit systems can return a signed integer
     // see warning here: http://php.net/manual/en/function.crc32.php
     public static function unsigned_crc32($v) {
-        return intval(sprintf("%u", crc32($v)));
+        return (int)sprintf( "%u", crc32($v));
     }
 }

--- a/src/Imgix/UrlBuilder.php
+++ b/src/Imgix/UrlBuilder.php
@@ -41,7 +41,7 @@ class UrlBuilder {
         $this->useHttps = $useHttps;
     }
 
-    public function createURL($path, $params=array()) {
+    public function createURL($path, $params=array(), $rawEncodePath = false) {
         $scheme = $this->useHttps ? "https" : "http";
 
         if ($this->shardStrategy === ShardStrategy::CRC) {
@@ -58,7 +58,7 @@ class UrlBuilder {
             $params['ixlib'] = "php-" . $this->currentVersion;
         }
 
-        $uh = new UrlHelper($domain, $path, $scheme, $this->signKey, $params);
+        $uh = new UrlHelper($domain, $path, $scheme, $this->signKey, $params, $rawEncodePath);
 
         return $uh->getURL();
     }

--- a/src/Imgix/UrlBuilder.php
+++ b/src/Imgix/UrlBuilder.php
@@ -4,7 +4,7 @@ namespace Imgix;
 
 class UrlBuilder {
 
-    private $currentVersion = "1.1.1";
+    private $currentVersion = "1.1.0";
     private $domains;
     private $useHttps;
     private $signKey;
@@ -66,6 +66,6 @@ class UrlBuilder {
     // force unsigned int since 32-bit systems can return a signed integer
     // see warning here: http://php.net/manual/en/function.crc32.php
     public static function unsigned_crc32($v) {
-        return (int)sprintf( "%u", crc32($v));
+        return (int)sprintf("%u", crc32($v));
     }
 }

--- a/src/Imgix/UrlBuilder.php
+++ b/src/Imgix/UrlBuilder.php
@@ -4,7 +4,7 @@ namespace Imgix;
 
 class UrlBuilder {
 
-    private $currentVersion = "1.1.0";
+    private $currentVersion = "1.1.1";
     private $domains;
     private $useHttps;
     private $signKey;

--- a/src/Imgix/UrlHelper.php
+++ b/src/Imgix/UrlHelper.php
@@ -18,8 +18,7 @@ class UrlHelper {
         $this->params = $params;
     }
 
-    public function formatPath($path, $rawUrlEncode )
-    {
+    public function formatPath($path, $rawUrlEncode ) {
         if (0 === strpos($path, "http"))
             $path = $rawUrlEncode ? rawurlencode($path) : urlencode($path);
 
@@ -37,8 +36,8 @@ class UrlHelper {
         }
     }
 
-    public function deleteParamter($key) {
-        $this->deleteParamter($key, "");
+    public function deleteParameter($key) {
+        unset($this->params[$key]);
     }
 
     public function getURL() {

--- a/src/Imgix/UrlHelper.php
+++ b/src/Imgix/UrlHelper.php
@@ -10,13 +10,21 @@ class UrlHelper {
     private $signKey;
     private $params;
 
-    public function __construct($domain, $path, $scheme = "http", $signKey = "", $params = array()) {
+    public function __construct($domain, $path, $scheme = "http", $signKey = "", $params = array(), $rawEncodePath = false) {
         $this->domain = $domain;
-        $this->path = substr($path, 0, 4) === "http" ? urlencode($path) : $path;
-        $this->path = substr($this->path, 0, 1) !== "/" ? ("/" . $this->path) : $this->path;
+        $this->path = $this->formatPath( $path, $rawEncodePath );
         $this->scheme = $scheme;
         $this->signKey = $signKey;
         $this->params = $params;
+    }
+
+    public function formatPath($path, $rawUrlEncode )
+    {
+        if (0 === strpos($path, "http"))
+            $path = $rawUrlEncode ? rawurlencode($path) : urlencode($path);
+
+        $path = ($path[0] === '/' ? '' : '/') . $path;
+        return $path;
     }
 
     public function setParameter($key, $value) {

--- a/tests/Imgix/Tests/UrlBuilderTest.php
+++ b/tests/Imgix/Tests/UrlBuilderTest.php
@@ -126,5 +126,21 @@ class UrlBuilderTest extends PHPUnit_Framework_TestCase {
 
         $this->assertEquals("https://demos.imgix.net/https%3A%2F%2Fmy-demo-site.com%2Ffiles%2F133467012%2Favatar+icon.png%3Fsome%3Dchill%26params%3D1?ixlib=php-" . $version, $url);
     }
+
+    public function testRawEncodePath() {
+        $builder    = new UrlBuilder("example.com");
+        $path       = "https://example.com/~.jpg";
+        $url        = $builder->createURL($path, [], true);
+
+        $this->assertContains('~.jpg', $url);
+    }
+
+    public function testNoRawEncodePath() {
+        $builder    = new UrlBuilder("example.com");
+        $path       = "https://example.com/~.jpg";
+        $url        = $builder->createURL($path);
+
+        $this->assertContains('%7E.jpg', $url);
+    }
   }
 ?>

--- a/tests/Imgix/Tests/UrlBuilderTest.php
+++ b/tests/Imgix/Tests/UrlBuilderTest.php
@@ -3,9 +3,7 @@
 use Imgix\UrlBuilder;
 use Imgix\ShardStrategy;
 
-require_once 'PHPUnit/Autoload.php';
-
-class UrlBuilderTest extends PHPUnit_Framework_TestCase {
+class UrlBuilderTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @expectedException        InvalidArgumentException

--- a/tests/Imgix/Tests/UrlBuilderTest.php
+++ b/tests/Imgix/Tests/UrlBuilderTest.php
@@ -3,6 +3,8 @@
 use Imgix\UrlBuilder;
 use Imgix\ShardStrategy;
 
+require_once 'PHPUnit/Autoload.php';
+
 class UrlBuilderTest extends PHPUnit_Framework_TestCase {
 
     /**

--- a/tests/Imgix/Tests/UrlHelperTest.php
+++ b/tests/Imgix/Tests/UrlHelperTest.php
@@ -2,6 +2,8 @@
 
 use Imgix\UrlHelper;
 
+require_once 'PHPUnit/Autoload.php';
+
 class UrlHelperTest extends PHPUnit_Framework_TestCase {
 
     public function testHelperBuildSignedURLWithHashMapParams() {

--- a/tests/Imgix/Tests/UrlHelperTest.php
+++ b/tests/Imgix/Tests/UrlHelperTest.php
@@ -2,9 +2,7 @@
 
 use Imgix\UrlHelper;
 
-require_once 'PHPUnit/Autoload.php';
-
-class UrlHelperTest extends PHPUnit_Framework_TestCase {
+class UrlHelperTest extends \PHPUnit\Framework\TestCase {
 
     public function testHelperBuildSignedURLWithHashMapParams() {
         $params = array("w" => 500);


### PR DESCRIPTION
This PR is aiming to fix an issue with urls that have for example tilde in their url.
There was a discussion with Pedro Aguilar from customer support about this.

Background
> Imgix PHP Library uses urlencode() in the UrlHelper converting ~ to %7E. Chrome will resolve this to ~ and the signed md5 hash won’t work.

Another approach with perhaps the same objective is in #26 