### PR TITLE
Ensure $path is a string in UrlHelper->formatPath

### DIFF
--- a/src/Imgix/UrlHelper.php
+++ b/src/Imgix/UrlHelper.php
@@ -19,6 +19,9 @@ class UrlHelper {
     }
 
     public function formatPath($path, $rawUrlEncode ) {
+        if (!is_string($path) || strlen($path) < 1)
+            return '/';
+
         if (0 === strpos($path, "http"))
             $path = $rawUrlEncode ? rawurlencode($path) : urlencode($path);
 


### PR DESCRIPTION
This PR fixes a regression in version 1.2, as pointed out in #28.

@aronj care to take a look at this for me?