### PR TITLE
Fix path encoding

### DIFF
--- a/src/Imgix/UrlBuilder.php
+++ b/src/Imgix/UrlBuilder.php
@@ -41,7 +41,7 @@ class UrlBuilder {
         $this->useHttps = $useHttps;
     }
 
-    public function createURL($path, $params=array(), $rawEncodePath = false) {
+    public function createURL($path, $params=array()) {
         $scheme = $this->useHttps ? "https" : "http";
 
         if ($this->shardStrategy === ShardStrategy::CRC) {
@@ -58,7 +58,7 @@ class UrlBuilder {
             $params['ixlib'] = "php-" . $this->currentVersion;
         }
 
-        $uh = new UrlHelper($domain, $path, $scheme, $this->signKey, $params, $rawEncodePath);
+        $uh = new UrlHelper($domain, $path, $scheme, $this->signKey, $params);
 
         return $uh->getURL();
     }

--- a/src/Imgix/UrlHelper.php
+++ b/src/Imgix/UrlHelper.php
@@ -25,7 +25,7 @@ class UrlHelper {
         // Strip leading slash first (we'll re-add after encoding)
         $path = preg_replace("/^\//", "", $path);
 
-        if (0 === strpos($path, "http")) {
+        if (preg_match("/^https?:\/\//", $path)) {
             // If this path is a full URL, encode the entire thing
             $path = rawurlencode($path);
 

--- a/src/Imgix/UrlHelper.php
+++ b/src/Imgix/UrlHelper.php
@@ -22,11 +22,22 @@ class UrlHelper {
         if (!is_string($path) || strlen($path) < 1)
             return '/';
 
-        if (0 === strpos($path, "http"))
+        // Strip leading slash first (we'll re-add after encoding)
+        $path = preg_replace("/^\//", "", $path);
+
+        if (0 === strpos($path, "http")) {
+            // If this path is a full URL, encode the entire thing
             $path = rawurlencode($path);
 
-        $path = ($path[0] === '/' ? '' : '/') . $path;
-        return $path;
+        } else {
+            // If this path is just a path, only encode certain characters
+            $path = preg_replace_callback("/([^\w\-\/\:@])/", function ($match) {
+                return rawurlencode($match[0]);
+            }, $path);
+        }
+
+        // Add a leading slash before returning
+        return '/' . $path;
     }
 
     public function setParameter($key, $value) {

--- a/src/Imgix/UrlHelper.php
+++ b/src/Imgix/UrlHelper.php
@@ -10,20 +10,20 @@ class UrlHelper {
     private $signKey;
     private $params;
 
-    public function __construct($domain, $path, $scheme = "http", $signKey = "", $params = array(), $rawEncodePath = false) {
+    public function __construct($domain, $path, $scheme = "http", $signKey = "", $params = array()) {
         $this->domain = $domain;
-        $this->path = $this->formatPath( $path, $rawEncodePath );
+        $this->path = $this->formatPath($path);
         $this->scheme = $scheme;
         $this->signKey = $signKey;
         $this->params = $params;
     }
 
-    public function formatPath($path, $rawUrlEncode ) {
+    public function formatPath($path) {
         if (!is_string($path) || strlen($path) < 1)
             return '/';
 
         if (0 === strpos($path, "http"))
-            $path = $rawUrlEncode ? rawurlencode($path) : urlencode($path);
+            $path = rawurlencode($path);
 
         $path = ($path[0] === '/' ? '' : '/') . $path;
         return $path;

--- a/tests/Imgix/Tests/UrlBuilderTest.php
+++ b/tests/Imgix/Tests/UrlBuilderTest.php
@@ -107,7 +107,7 @@ class UrlBuilderTest extends \PHPUnit\Framework\TestCase {
         $builder->setSignKey("test1234");
         $url = $builder->createUrl("https://my-demo-site.com/files/133467012/avatar icon.png");
 
-        $this->assertEquals("https://demos.imgix.net/https%3A%2F%2Fmy-demo-site.com%2Ffiles%2F133467012%2Favatar+icon.png?s=1f65f21dab7da2d3c104dfaf898ce8cc", $url);
+        $this->assertEquals("https://demos.imgix.net/https%3A%2F%2Fmy-demo-site.com%2Ffiles%2F133467012%2Favatar%20icon.png?s=6a1d47f292194cfa7573da0e2bb6b0f4", $url);
     }
 
     public function testWithFullyQualifiedUrlWithParams() {
@@ -115,7 +115,7 @@ class UrlBuilderTest extends \PHPUnit\Framework\TestCase {
         $builder->setSignKey("test1234");
         $url = $builder->createUrl("https://my-demo-site.com/files/133467012/avatar icon.png?some=chill&params=1");
 
-        $this->assertEquals("https://demos.imgix.net/https%3A%2F%2Fmy-demo-site.com%2Ffiles%2F133467012%2Favatar+icon.png%3Fsome%3Dchill%26params%3D1?s=970429e4d150c4609142f4c0a86089c9", $url);
+        $this->assertEquals("https://demos.imgix.net/https%3A%2F%2Fmy-demo-site.com%2Ffiles%2F133467012%2Favatar%20icon.png%3Fsome%3Dchill%26params%3D1?s=bbc73c61ebc739337b852ff8423a1da9", $url);
     }
 
     public function testInclusionOfLibraryVersionParam() {
@@ -124,7 +124,7 @@ class UrlBuilderTest extends \PHPUnit\Framework\TestCase {
         $composerFileJson = json_decode(file_get_contents("./composer.json"), true);
         $version = $composerFileJson['version'];
 
-        $this->assertEquals("https://demos.imgix.net/https%3A%2F%2Fmy-demo-site.com%2Ffiles%2F133467012%2Favatar+icon.png%3Fsome%3Dchill%26params%3D1?ixlib=php-" . $version, $url);
+        $this->assertEquals("https://demos.imgix.net/https%3A%2F%2Fmy-demo-site.com%2Ffiles%2F133467012%2Favatar%20icon.png%3Fsome%3Dchill%26params%3D1?ixlib=php-" . $version, $url);
     }
   }
 ?>

--- a/tests/Imgix/Tests/UrlBuilderTest.php
+++ b/tests/Imgix/Tests/UrlBuilderTest.php
@@ -126,21 +126,5 @@ class UrlBuilderTest extends \PHPUnit\Framework\TestCase {
 
         $this->assertEquals("https://demos.imgix.net/https%3A%2F%2Fmy-demo-site.com%2Ffiles%2F133467012%2Favatar+icon.png%3Fsome%3Dchill%26params%3D1?ixlib=php-" . $version, $url);
     }
-
-    public function testRawEncodePath() {
-        $builder    = new UrlBuilder("example.com");
-        $path       = "https://example.com/~.jpg";
-        $url        = $builder->createURL($path, [], true);
-
-        $this->assertContains('~.jpg', $url);
-    }
-
-    public function testNoRawEncodePath() {
-        $builder    = new UrlBuilder("example.com");
-        $path       = "https://example.com/~.jpg";
-        $url        = $builder->createURL($path);
-
-        $this->assertContains('%7E.jpg', $url);
-    }
   }
 ?>

--- a/tests/Imgix/Tests/UrlHelperTest.php
+++ b/tests/Imgix/Tests/UrlHelperTest.php
@@ -4,6 +4,65 @@ use Imgix\UrlHelper;
 
 class UrlHelperTest extends \PHPUnit\Framework\TestCase {
 
+    /*--- formatPath() ---*/
+    public function testHelperFormatPathWithSimplePath() {
+        $path = "dog.jpg";
+        $uh = new URLHelper("test.imgix.net", $path);
+
+        $this->assertEquals($uh->formatPath($path), "/" . $path);
+    }
+
+    public function testHelperFormatPathWithLeadingSlash() {
+        $path = "dog.jpg";
+        $uh = new URLHelper("test.imgix.net", $path);
+
+        $this->assertEquals($uh->formatPath("/" . $path), "/" . $path);
+    }
+
+    public function testHelperFormatPathWithUnencodedCharacters() {
+        $path = "images/püg.jpg";
+        $uh = new URLHelper("test.imgix.net", $path);
+
+        $this->assertEquals($uh->formatPath($path), "/images/p%C3%BCg.jpg");
+    }
+
+    public function testHelperFormatPathWithFullUrl() {
+        $path = "http://mywebsite.com/images/dog.jpg";
+        $uh = new URLHelper("test.imgix.net", $path);
+
+        $this->assertEquals($uh->formatPath($path), "/http%3A%2F%2Fmywebsite.com%2Fimages%2Fdog.jpg");
+    }
+
+    public function testHelperFormatPathWithFullHttpsUrl() {
+        $path = "https://mywebsite.com/images/dog.jpg";
+        $uh = new URLHelper("test.imgix.net", $path);
+
+        $this->assertEquals($uh->formatPath($path), "/https%3A%2F%2Fmywebsite.com%2Fimages%2Fdog.jpg");
+    }
+
+    public function testHelperFormatPathWithFullUrlWithUnencodedCharacters() {
+        $path = "http://mywebsite.com/images/püg.jpg";
+        $uh = new URLHelper("test.imgix.net", $path);
+
+        $this->assertEquals($uh->formatPath($path), "/http%3A%2F%2Fmywebsite.com%2Fimages%2Fp%C3%BCg.jpg");
+    }
+
+    public function testHelperFormatPathWithFullUrlWithLeadingSlash() {
+        $path = "/http://mywebsite.com/images/dog.jpg";
+        $uh = new URLHelper("test.imgix.net", $path);
+
+        $this->assertEquals($uh->formatPath($path), "/http%3A%2F%2Fmywebsite.com%2Fimages%2Fdog.jpg");
+    }
+
+    public function testHelperFormatPathWithFullUrlWithEncodedCharacters() {
+        $path = "http://mywebsite.com/images/p%C3%BCg.jpg";
+        $uh = new URLHelper("test.imgix.net", $path);
+
+        // The pre-encoded characters should now be *double* encoded
+        $this->assertEquals($uh->formatPath($path), "/http%3A%2F%2Fmywebsite.com%2Fimages%2Fp%25C3%25BCg.jpg");
+    }
+
+    /*--- getURL() ---*/
     public function testHelperBuildSignedURLWithHashMapParams() {
         $params = array("w" => 500);
         $uh = new URLHelper("imgix-library-secure-test-source.imgix.net", "dog.jpg", "http", "EHFQXiZhxP4wA2c4", $params);


### PR DESCRIPTION
This PR fixes the path-encoding logic for this library, to bring it in line with other libraries in our SDK. The logic is as follows:

- **All paths are expected to be passed in unencoded.** If a path is provided that is already encoded, it will become double-encoded.
- **If the path matches `/^https?:\/\//`, it will be fully encoded, slashes and all.** In this case, we're assuming it's a fully-qualified URL (this is necessary for [web proxy sources](https://docs.imgix.com/setup/creating-sources/web-proxy)). We had previously been using `urlencode()` for this, but [version 1.2.0](https://github.com/imgix/imgix-php/releases/tag/1.2.0) introduced an option to use `rawurlencode()` instead. This PR removes that option and uses `rawurlencode()` in all cases. The general consensus in the PHP community seems to be that `rawurlencode()` is strictly better for our use-case--see [this SO thread](https://stackoverflow.com/questions/996139/urlencode-vs-rawurlencode) for more info.
- **If the path does not match `/^https?:\/\//`, it will be partially-encoded**. Non-URL-safe characters (everything that matches `/([^\w\-\/\:@])/`) will be encoded with `rawurlencode()`, and all other characters will be left alone.

In addition, I added tests for the `UrlHelper.formatPath()` method. Test coverage in this library is still wildly insufficient, but this PR at least makes things better than they were yesterday.

Note: this PR should fix #28.