### PR TITLE
Add includeLibraryParam setter

### DIFF
--- a/src/Imgix/UrlBuilder.php
+++ b/src/Imgix/UrlBuilder.php
@@ -41,6 +41,10 @@ class UrlBuilder {
         $this->useHttps = $useHttps;
     }
 
+    public function setIncludeLibraryParam($includeLibraryParam) {
+        $this->includeLibraryParam = $includeLibraryParam;
+    }
+
     public function createURL($path, $params=array()) {
         $scheme = $this->useHttps ? "https" : "http";
 


### PR DESCRIPTION
Adds a `setIncludeLibraryParam` setter method in the same style as the other constructor options. Without it it's required to pass through all arguments to the constructor which is not ideal without named parameters.

Before:

``` php
$builder = new UrlBuilder(
    'some-imgx-domain.example.com',
    true,
    "",
    ShardStrategy::CRC,
    false
);
```

After:

``` php
$builder = new UrlBuilder('some-imgx-domain.example.com');
$builder->setUseHttps(true);
$builder->setIncludeLibraryParam(false);
```