### PR TITLE
Don't double encode URLs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,7 @@ script: phpunit --bootstrap src/autoload.php tests
 php:
   - '5.6'
   - '7.0'
+  - '7.1'
+  - '7.2'
 install:
   - composer install

--- a/src/Imgix/UrlHelper.php
+++ b/src/Imgix/UrlHelper.php
@@ -28,7 +28,14 @@ class UrlHelper {
         if (preg_match("/^https?:\/\//", $path)) {
             // If this path is a full URL, encode the entire thing
             $path = rawurlencode($path);
-
+        } else if (preg_match("/^https?:\/\/[^\s\/$.?#]*\.[^\s]*$/", rawurldecode($path))) {
+            // Using @stephenhay's solution from https://mathiasbynens.be/demo/url-regex
+            // to ensure URL's validity.
+            // $path looks like a valid encoded URL, however, it may still have
+            // unencoded unicode characters.
+            $path = preg_replace_callback("/([^\w\-\/\:@%])/", function ($match) {
+                return rawurlencode($match[0]);
+            }, $path);
         } else {
             // If this path is just a path, only encode certain characters
             $path = preg_replace_callback("/([^\w\-\/\:@])/", function ($match) {
@@ -92,7 +99,7 @@ class UrlHelper {
     }
 
     private static function base64url_encode($data) {
-      return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
     }
 
     private static function joinURL($parts) {

--- a/tests/Imgix/Tests/UrlHelperTest.php
+++ b/tests/Imgix/Tests/UrlHelperTest.php
@@ -62,6 +62,34 @@ class UrlHelperTest extends \PHPUnit\Framework\TestCase {
         $this->assertEquals($uh->formatPath($path), "/http%3A%2F%2Fmywebsite.com%2Fimages%2Fp%25C3%25BCg.jpg");
     }
 
+    public function testHelperFormatPathHttpsURLAlreadyEncoded() {
+        $path = "https%3A%2F%2Fmywebsite.com%2Fimages%2Ffoo.JPG";
+        $uh = new URLHelper("test.imgix.net", $path);
+
+        $this->assertEquals($uh->formatPath($path), "/https%3A%2F%2Fmywebsite.com%2Fimages%2Ffoo.JPG");
+    }
+
+    public function testHelperFormatPathHttspURLAlreadyEncodedWithSpecialCharacters() {
+        $path = "http%3A%2F%2Fmywebsite.com%2Fimages%2Fpüg.jpg";
+        $uh = new URLHelper("test.imgix.net", $path);
+
+        $this->assertEquals($uh->formatPath($path), "/http%3A%2F%2Fmywebsite.com%2Fimages%2Fp%C3%BCg.jpg");
+    }
+
+    public function testHelperFormatPathHttpURLAlreadyEncoded() {
+        $path = "http%3A%2F%2Fmywebsite.com%2Fimages%2Ffoo.JPG";
+        $uh = new URLHelper("test.imgix.net", $path);
+
+        $this->assertEquals($uh->formatPath($path), "/http%3A%2F%2Fmywebsite.com%2Fimages%2Ffoo.JPG");
+    }
+
+    public function testHelperFormatPathInvalidURLEncoded() {
+        $path = "http%2F%2Fmywebsite.com%2Fimages%2FFoo.JPG";
+        $uh = new URLHelper("test.imgix.net", $path);
+
+        $this->assertEquals($uh->formatPath($path), "/http%252F%252Fmywebsite.com%252Fimages%252FFoo.JPG");
+    }
+
     /*--- getURL() ---*/
     public function testHelperBuildSignedURLWithHashMapParams() {
         $params = array("w" => 500);


### PR DESCRIPTION
Currently, if an already encoded URL is passed as path, it gets double encoded --`http%3A%2F%2Ffoo.bar%2Fbaz.png` encoded as `http%253A%252F%252Ffoo.bar%252Fbaz.png`.

This PR avoids double encoding only if the the input is a _valid_ encoded URL. If the URL is found to be invalid, it will be encoded as usual (`%` characters being replaced with `%25`).

The encoding is performed as usual for all other cases.