### PR TITLE
Add a function to reteive the current version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "imgix/imgix-php",
   "description": "A PHP client library for generating URLs with imgix.",
   "type": "library",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "license": "BSD-2-Clause",
   "keywords": [
     "imgix"

--- a/src/Imgix/UrlBuilder.php
+++ b/src/Imgix/UrlBuilder.php
@@ -67,6 +67,10 @@ class UrlBuilder {
         return $uh->getURL();
     }
 
+    public function getCurrentVersion() {
+        return $this->currentVersion;
+    }
+
     // force unsigned int since 32-bit systems can return a signed integer
     // see warning here: http://php.net/manual/en/function.crc32.php
     public static function unsigned_crc32($v) {

--- a/src/Imgix/UrlBuilder.php
+++ b/src/Imgix/UrlBuilder.php
@@ -4,7 +4,7 @@ namespace Imgix;
 
 class UrlBuilder {
 
-    private $currentVersion = "2.1.1";
+    private $currentVersion = "2.1.2";
     private $domains;
     private $useHttps;
     private $signKey;


### PR DESCRIPTION
I found it useful being able to access the current version number when testing writing tests that involve calls to imgix. 