### PR TITLE
fix: replace deprecated phpunit annotations with exception methods

### DIFF
--- a/tests/Imgix/Tests/UrlBuilderTest.php
+++ b/tests/Imgix/Tests/UrlBuilderTest.php
@@ -5,11 +5,9 @@ use Imgix\ShardStrategy;
 
 class UrlBuilderTest extends \PHPUnit\Framework\TestCase {
 
-    /**
-     * @expectedException        InvalidArgumentException
-     * @expectedExceptionMessage UrlBuilder requires at least one domain
-     */
     public function testURLBuilderRaisesExceptionOnNoDomains() {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("UrlBuilder requires at least one domain");
         $domains = array();
         $ub = new URLBuilder($domains);
     }


### PR DESCRIPTION
This PR replaces the deprecated `@expectedException` and `@expectedExceptionMessage` annotations with the preferred exception method equivalents.