### PR TITLE
fix: flatten nested array in $params

### DIFF
--- a/src/Imgix/UrlHelper.php
+++ b/src/Imgix/UrlHelper.php
@@ -71,7 +71,7 @@ class UrlHelper {
                 if (substr($key, -2) == '64') {
                     $encodedVal = self::base64url_encode($val);
                 } else {
-                    $encodedVal = rawurlencode($val);
+                    $encodedVal = is_array($val) ? rawurlencode(implode(',',$val)) : rawurlencode($val);
                 }
 
                 $queryPairs[] = rawurlencode($key) . "=" . $encodedVal;

--- a/tests/Imgix/Tests/UrlBuilderTest.php
+++ b/tests/Imgix/Tests/UrlBuilderTest.php
@@ -124,5 +124,12 @@ class UrlBuilderTest extends \PHPUnit\Framework\TestCase {
 
         $this->assertEquals("https://demos.imgix.net/https%3A%2F%2Fmy-demo-site.com%2Ffiles%2F133467012%2Favatar%20icon.png%3Fsome%3Dchill%26params%3D1?ixlib=php-" . $version, $url);
     }
+    public function testNestedParameters(){
+        $builder = new UrlBuilder("demos.imgix.net", true, "", ShardStrategy::CRC, false);
+        $params = array("auto" => array("compress","format"));
+        $url = $builder->createURL("bridge.png", $params);
+
+        $this->assertEquals("https://demos.imgix.net/bridge.png?auto=compress%2Cformat", $url);
+    }
   }
 ?>


### PR DESCRIPTION
Certain imgix URL parameters accept multiple comma-separated values, eg `auto=compress,format`. This PR will flatten nested arrays passed into `$params`, separating them by commas.

For example, the following scenario would previously throw an error:

```php
$params = array("auto" => array("compress","format"));
$url = $builder->createURL("bridge.png", $params);
```
After flattening the array, it should now produce the following URL:
```
https://demos.imgix.net/bridge.png?auto=compress%2Cformat
```

Special thanks to @xuneXTW for catching this.