### PR TITLE
fix: add domain validation at UrlBuilder initialization

### DIFF
--- a/src/Imgix/UrlBuilder.php
+++ b/src/Imgix/UrlBuilder.php
@@ -23,10 +23,24 @@ class UrlBuilder {
             throw new \InvalidArgumentException("UrlBuilder requires at least one domain");
         }
 
+        $this->validateDomain($this->domains);        
+
         $this->useHttps = $useHttps;
         $this->signKey = $signKey;
         $this->shardStrategy = $shardStrategy;
         $this->includeLibraryParam = $includeLibraryParam;
+    }
+
+    private function validateDomain($domains) {
+        $DOMAIN_PATTERN = "/^(?:[a-z\d\-_]{1,62}\.){0,125}(?:[a-z\d](?:\-(?=\-*[a-z\d])|[a-z]|\d){0,62}\.)[a-z\d]{1,63}$/";
+
+        foreach($domains as $key => $val) {
+            if(!preg_match($DOMAIN_PATTERN, $val)) {
+                throw new \InvalidArgumentException('Domains must be passed in as fully-qualified ' . 
+                'domain names and should not include a protocol or any path element, i.e. ' .
+                '"example.imgix.net".'); 
+            }
+        }
     }
 
     public function setShardStrategy($start) {

--- a/tests/Imgix/Tests/UrlBuilderTest.php
+++ b/tests/Imgix/Tests/UrlBuilderTest.php
@@ -124,12 +124,44 @@ class UrlBuilderTest extends \PHPUnit\Framework\TestCase {
 
         $this->assertEquals("https://demos.imgix.net/https%3A%2F%2Fmy-demo-site.com%2Ffiles%2F133467012%2Favatar%20icon.png%3Fsome%3Dchill%26params%3D1?ixlib=php-" . $version, $url);
     }
-    public function testNestedParameters(){
+    public function testNestedParameters() {
         $builder = new UrlBuilder("demos.imgix.net", true, "", ShardStrategy::CRC, false);
         $params = array("auto" => array("compress","format"));
         $url = $builder->createURL("bridge.png", $params);
 
         $this->assertEquals("https://demos.imgix.net/bridge.png?auto=compress%2Cformat", $url);
+    }
+    public function test_invalid_domain_append_slash() {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Domains must be passed in as fully-qualified ' . 
+        'domain names and should not include a protocol or any path element, i.e. ' .
+        '"example.imgix.net".');
+
+        $builder = new UrlBuilder("demos.imgix.net/", true, "", ShardStrategy::CRC, false);
+    }
+    public function test_invalid_domain_prepend_scheme() {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Domains must be passed in as fully-qualified ' . 
+        'domain names and should not include a protocol or any path element, i.e. ' .
+        '"example.imgix.net".');
+        
+        $builder = new UrlBuilder("https://demos.imgix.net", true, "", ShardStrategy::CRC, false);
+    }
+    public function test_invalid_domain_append_dash() {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Domains must be passed in as fully-qualified ' . 
+        'domain names and should not include a protocol or any path element, i.e. ' .
+        '"example.imgix.net".');
+        
+        $builder = new UrlBuilder("demos.imgix.net-", true, "", ShardStrategy::CRC, false);
+    }
+    public function test_invalid_domain_array() {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Domains must be passed in as fully-qualified ' . 
+        'domain names and should not include a protocol or any path element, i.e. ' .
+        '"example.imgix.net".');
+        
+        $builder = new UrlBuilder(array("demos.imgix.net","demos.imgix.net-"), true, "", ShardStrategy::CYCLE, false);
     }
   }
 ?>


### PR DESCRIPTION
Adds a validation that will throw an error if a user attempts to initialize a new `UrlBuilder` object with an invalid domain.
The validation criteria is based off of the same regex used on [dashboard.imgix.com](https://dashboard.imgix.com)

Fixes #10 