### PR TITLE
fix: deprecate domain sharding

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ echo $builder->createURL("bridge.png", $params);
 ```
 
 ## Domain Sharded URLs
+**Warning: Domain Sharding has been deprecated and will be removed in the next major release**
 
 Domain sharding enables you to spread image requests across multiple domains.
 This allows you to bypass the requests-per-host limits of browsers. We

--- a/src/Imgix/UrlBuilder.php
+++ b/src/Imgix/UrlBuilder.php
@@ -16,6 +16,8 @@ class UrlBuilder {
         if (!is_array($domains)) {
             $this->domains = array($domains);
         } else {
+            $warning_message = "Warning: Domain sharding has been deprecated and will be removed in the next major version.";
+            @trigger_error($warning_message, E_USER_DEPRECATED);
             $this->domains = $domains;
         }
 

--- a/tests/Imgix/Tests/UrlBuilderTest.php
+++ b/tests/Imgix/Tests/UrlBuilderTest.php
@@ -163,5 +163,17 @@ class UrlBuilderTest extends \PHPUnit\Framework\TestCase {
         
         $builder = new UrlBuilder(array("demos.imgix.net","demos.imgix.net-"), true, "", ShardStrategy::CYCLE, false);
     }
+    public function test_deprecation_warning() {
+        # Tests for deprecation warning using a custom error handler
+        # as the warning is typically suppressed to prevent polluting 
+        # error logs
+        set_error_handler(function($errno, $errstr, $errfile, $errline) {
+            $warning_message = "Warning: Domain sharding has been deprecated and will be removed in the next major version.";
+            $this->assertEquals($warning_message, $errstr);
+            $this->assertEquals(E_USER_DEPRECATED, $errno);
+        }, E_USER_DEPRECATED);
+
+        $builder = new UrlBuilder(array("demos.imgix.net","demos.imgix.net"), true, "", ShardStrategy::CYCLE, false);
+    }
   }
 ?>


### PR DESCRIPTION
This PR begins the process of deprecating, and eventually removing, domain sharding from the imgix-php library.
The `UrlBuilder` object will now generate a warning when users attempt to initialize it by passing in multiple domains in the form of an array.