### PR TITLE
docs: use svg build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 `imgix-php` is a client library for generating image URLs with [imgix](https://www.imgix.com/).
 
 [![Version](https://poser.pugx.org/imgix/imgix-php/v/stable)](https://packagist.org/packages/imgix/imgix-php)
-[![Build Status](https://travis-ci.org/imgix/imgix-php.png?branch=master)](https://travis-ci.org/imgix/imgix-php)
+[![Build Status](https://travis-ci.org/imgix/imgix-php.svg?branch=master)](https://travis-ci.org/imgix/imgix-php)
 [![Downloads](https://img.shields.io/packagist/dt/imgix/imgix-php)](https://packagist.org/packages/imgix/imgix-php)
 [![License](https://img.shields.io/github/license/imgix/imgix-php)](https://github.com/imgix/imgix-php/blob/master/LICENSE)
 


### PR DESCRIPTION
Uses the svg version of the Travis build badge. Should have been included as part of #48 but got left out.