### PR TITLE
docs: use packagist badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 `imgix-php` is a client library for generating image URLs with [imgix](https://www.imgix.com/). It is tested under PHP versions `5.6`, `7.0`, `7.1`, and `7.2`
 
-[![Version](https://poser.pugx.org/imgix/imgix-php/v/stable)](https://packagist.org/packages/imgix/imgix-php)
+[![Version](https://img.shields.io/packagist/v/imgix/imgix-php.svg)](https://packagist.org/packages/imgix/imgix-php)
 [![Build Status](https://travis-ci.org/imgix/imgix-php.svg?branch=master)](https://travis-ci.org/imgix/imgix-php)
 [![Downloads](https://img.shields.io/packagist/dt/imgix/imgix-php)](https://packagist.org/packages/imgix/imgix-php)
 [![License](https://img.shields.io/github/license/imgix/imgix-php)](https://github.com/imgix/imgix-php/blob/master/LICENSE)


### PR DESCRIPTION
As a follow up to #48, use the badge directly from packagist to indicate the current package version.

Before:
![Screen Shot 2019-12-18 at 4 20 19 PM](https://user-images.githubusercontent.com/15919091/71134660-eef33400-21b3-11ea-9875-778e6ab3cb85.png)
After:
![Screen Shot 2019-12-18 at 4 20 12 PM](https://user-images.githubusercontent.com/15919091/71134661-f0246100-21b3-11ea-8f5d-7e78bc9ae58c.png)
