### PR TITLE
chore(release): 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 <a name="3.2.0"></a>
 
-## [3.2.0](https://github.com/imgix/imgix-php/compare/3.0.0...3.2.0) (2020-03-31)
+## [3.2.0](https://github.com/imgix/imgix-php/compare/3.1.0...3.2.0) (2020-03-31)
 
 * feat: use https by default ([#53](https://github.com/imgix/imgix-php/pull/53))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="3.2.0"></a>
+
+## [3.2.0](https://github.com/imgix/imgix-php/compare/3.0.0...3.2.0) (2020-03-31)
+
+* feat: use https by default ([#53](https://github.com/imgix/imgix-php/pull/53))
+
 <a name="3.1.0"></a>
 
 ## [3.1.0](https://github.com/imgix/imgix-php/compare/3.0.0...3.1.0) (2019-08-29)

--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ echo $builder->createURL("bridge.png", $params);
 // http://demos.imgix.net/bridge.png?h=100&w=100
 ```
 
-For HTTPS support, simply use the setter `setUseHttps` on the builder
+Currently, HTTPS support is available _by default_. However, if you need HTTP support, simply call `setUseHttps` on the builder:
 
 ```php
 use Imgix\UrlBuilder;
 
 $builder = new UrlBuilder("demos.imgix.net");
-$builder->setUseHttps(true);
+$builder->setUseHttps(false);
 $params = array("w" => 100, "h" => 100);
 echo $builder->createURL("bridge.png", $params);
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ And include the global `vendor/autoload.php` autoloader.
 
 ## Usage
 
-To begin creating imgix URLs programmatically, simply add the php files to your project (an example autoloader is also provided). The URL builder can be reused to create URLs for any
+To begin creating imgix URLs programmatically, add the php files to your project (an example autoloader is also provided). The URL builder can be reused to create URLs for any
 images on the domains it is provided.
 
 ```php

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ echo $builder->createURL("bridge.png", $params);
 // http://demos.imgix.net/bridge.png?h=100&w=100
 ```
 
-Currently, HTTPS support is available _by default_. However, if you need HTTP support, simply call `setUseHttps` on the builder:
+HTTPS support is available _by default_. However, if you need HTTP support, call `setUseHttps` on the builder:
 
 ```php
 use Imgix\UrlBuilder;

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "imgix/imgix-php",
   "description": "A PHP client library for generating URLs with imgix.",
   "type": "library",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "license": "BSD-2-Clause",
   "keywords": [
     "imgix"

--- a/src/Imgix/UrlBuilder.php
+++ b/src/Imgix/UrlBuilder.php
@@ -4,7 +4,7 @@ namespace Imgix;
 
 class UrlBuilder {
 
-    private $currentVersion = "3.1.0";
+    private $currentVersion = "3.2.0";
     private $domain;
     private $useHttps;
     private $signKey;


### PR DESCRIPTION
This commit updates the release version throughout the project. The
version is being updated due to a change made to the default behavior
of the API. Prior to the change, `http` was used by default. Now,
`https` is being used by default. To ensure I've changed the version
everywhere that it appears, I `ripgrep`'d (grep) for "3.1.1".

After changing the version, I grepped for "3.2.0" with the following
results:

```text
composer.json
5:  "version": "3.2.0",

CHANGELOG.md
5:<a name="3.2.0"></a>
7:## [3.2.0](https://github.com/imgix/imgix-php/compare/3.0.0...3.2.0) (2020-03-31)

src/Imgix/UrlBuilder.php
7:    private $currentVersion = "3.2.0";
```

This squares with the modified files:

```text
modified:   CHANGELOG.md
modified:   composer.json
modified:   src/Imgix/UrlBuilder.php

modified:   README.md
```

This commit also modifies the project README to reflect the new default behavior.