### PR TITLE
refactor: normalize behavior of target widths

### DIFF
--- a/src/Imgix/UrlBuilder.php
+++ b/src/Imgix/UrlBuilder.php
@@ -109,11 +109,16 @@ class UrlBuilder {
      * @return int[] $resolutions An array of even integer values.
      */
     public function targetWidths($start=100, $stop=8192, $tol=8) {
-        $resolutions = array();
 
         $ensureEven = function($n) {
             return intval(2 * round($n / 2.0));
         };
+
+        if ($start == $stop) {
+            return array($ensureEven($start));
+        }
+
+        $resolutions = array();
 
         while ($start < $stop && $start < 8192) {
             array_push($resolutions, $ensureEven($start));


### PR DESCRIPTION
This PR seeks to normalize the behavior of target widths (kit wide).
Prior, it was an error (python) to set start = stop when generating
a range of target width values. This has been relaxed and it is no longer
an error making generating target width lists of length 1 possible.