### PR TITLE
refactor: change tolerance from int -> float

### DIFF
--- a/src/Imgix/UrlBuilder.php
+++ b/src/Imgix/UrlBuilder.php
@@ -23,7 +23,7 @@ class UrlBuilder {
 
     const MIN_WIDTH = 100;
     const MAX_WIDTH = 8192;
-    const SRCSET_WIDTH_TOLERANCE = 8;
+    const SRCSET_WIDTH_TOLERANCE = 0.08;
 
     // constants cannot be dynamically assigned; keeping as a class variable instead
     private $targetWidths;
@@ -134,7 +134,7 @@ class UrlBuilder {
 
         while ($start < $stop && $start < self::MAX_WIDTH) {
             array_push($resolutions, (int) round($start));
-            $start *= 1 + ($tol / 100.0) * 2;
+            $start *= 1 + $tol * 2;
         }
 
         // The most recently appended value may, or may not, be

--- a/tests/Imgix/Tests/UrlBuilderTest.php
+++ b/tests/Imgix/Tests/UrlBuilderTest.php
@@ -235,7 +235,7 @@ https://demos.imgix.net/image.jpg?ixlib=php-3.2.0&w=720 720w';
 
         // Now test custom tolerances (also within a range).
         $builder = new UrlBuilder("demos.imgix.net", true, false);
-        $opts = array('start' => 100, 'stop' => 108, 'tol' => 1);
+        $opts = array('start' => 100, 'stop' => 108, 'tol' => 0.01);
         $actual = $builder->createSrcSet($path="image.jpg", $params=array(), $options=$opts);
         $expected = // Raw string literal
 'https://demos.imgix.net/image.jpg?ixlib=php-3.2.0&w=100 100w,


### PR DESCRIPTION
Prior to this PR, width `tol`erance was expected to be of type `int`
and within the range of `[1, 100]` or "one to one hundred percent."
Now, `tol` is expected to be a `float` in the range `[0.01, 1.0]` which
also represents "one to one hundred percent."

We have done this for consistency purposes, i.e. [imgix-core-js](https://github.com/imgix/imgix-core-js/blob/2c9d97a7ab54c7a8fec378732bdcb855cef41907/src/imgix-core-js.js#L25) uses
floating point values. Since `imgix-core-js` was impl'd first, we defer
to this tried/tested interface. This way, this feature is standard
and consistent kit-wide.