### PR TITLE
feat: validate custom srcsets

### DIFF
--- a/src/Imgix/UrlBuilder.php
+++ b/src/Imgix/UrlBuilder.php
@@ -2,6 +2,8 @@
 
 namespace Imgix;
 
+use Imgix\Validator;
+
 class UrlBuilder {
 
     private $currentVersion = "3.2.0";
@@ -82,6 +84,7 @@ class UrlBuilder {
         $widthsArray = isset($options['widths']) ? $options['widths'] : NULL;
 
         if (isset($widthsArray)) {
+            Validator::validateWidths($widthsArray);
             return $this->createSrcSetPairs($path, $params=$params, $widthsArray);
         }
         
@@ -130,6 +133,7 @@ class UrlBuilder {
             return array((int) $start);
         }
 
+        Validator::validateMinMaxTol($start, $stop, $tol);
         $resolutions = array();
 
         while ($start < $stop && $start < self::MAX_WIDTH) {

--- a/src/Imgix/Validator.php
+++ b/src/Imgix/Validator.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Imgix;
+
+class Validator {
+    const ONE_PERCENT = 0.01;
+
+    public static function validateMinWidth($start) {
+        if ($start < 0) {
+            throw new \InvalidArgumentException("`start` width value must be greater than zero");
+        }
+    }
+
+    public static function validateMaxWidth($end) {
+        if ($end < 0) {
+            throw new \InvalidArgumentException("`stop` width value must be greater than zero"); 
+        }
+    }
+
+    public static function validateRange($start, $stop) {
+        // Validate the minimum width, `begin`.
+        Validator::validateMinWidth($start);
+        // Validate the maximum width, `end`.
+        Validator::validateMaxWidth($stop);
+
+        // Ensure that the range is valid, ie. `begin <= end`.
+        if ($start > $stop) {
+            throw new \InvalidArgumentException("`start` width value must be less than `stop` width value"); 
+        }
+    }
+
+    public static function validateTolerance($tol) {
+        $msg = "`tol`erance value must be greater than, or equal to one percent, ie. >= 0.01";
+
+        if ($tol < self::ONE_PERCENT) {
+            throw new \InvalidArgumentException($msg);
+        }
+    }
+
+    public static function validateMinMaxTol($begin, $end, $tol) {
+        Validator::validateRange($begin, $end);
+        Validator::validateTolerance($tol);
+    }
+
+    public static function validateWidths($widths) {
+        if ($widths == NULL) {
+            throw new \InvalidArgumentException("`widths` array cannot be `null`");
+        }
+
+        if (count($widths) == 0) {
+            throw new \InvalidArgumentException("`widths` array cannot be empty");
+        }
+        foreach ($widths as &$w) {
+            if ($w < 0) {
+                throw new \InvalidArgumentException("width values in `widths` cannot be negative");
+            }
+        }
+    }
+}
+?>

--- a/tests/Imgix/Tests/ValidatorTest.php
+++ b/tests/Imgix/Tests/ValidatorTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use Imgix\Validator;
+
+class ValidatorTest extends \PHPUnit\Framework\TestCase {
+    const LESS_THAN_ZERO = -1;
+    /**
+     * Test `validateMinWidth` throws if passed a value less than
+     * zero.
+     */
+    public function testValidateMinWidth() {
+        $this->expectException(InvalidArgumentException::class);
+        Validator::validateMinWidth(self::LESS_THAN_ZERO);
+    }
+
+    /**
+     * Test `validateMaxWidth` throws if passed a value less than
+     * zero.
+     */
+    public function testValidateMaxWidth() {
+        $this->expectException(InvalidArgumentException::class);
+        Validator::validateMaxWidth(self::LESS_THAN_ZERO);
+    }
+
+    /**
+     * Test `validateRange` throws if passed an invalid range,
+     * ie. if `BEGIN > END`.
+     */
+    public function testValidateRange() {
+        $this->expectException(InvalidArgumentException::class);
+        $begin = 400;
+        $end = 100;
+        Validator::validateRange($begin, $end);
+    }
+
+    /**
+     * Test `validateTolerance` throws if passed a `tol`erance
+     * that is less than one percent.
+     */
+    public function testValidateTolerance() {
+        $this->expectException(InvalidArgumentException::class);
+        $lessThanOnePercent = 0.001;
+        Validator::validateTolerance($lessThanOnePercent);
+    }
+
+
+    /**
+     * Test `validateWidths` throws if passed a `null` array.
+     */
+    public function testValidateWidthsNullArray() {
+        $this->expectException(InvalidArgumentException::class);
+        Validator::validateWidths(NULL);
+    }
+
+    /**
+     * Test `validateWidths` throws if passed an empty array.
+     */
+    public function testValidateWidthsEmptyArray() {
+        $this->expectException(InvalidArgumentException::class);
+        Validator::validateWidths([]);
+    }
+}
+?>


### PR DESCRIPTION
This PR implements basic validation for `start`, `stop`, `tol`, and
`widths`.

**When invalid input is encountered an exception will be thrown.**

Specifically, a `InvalidArgumentException` is thrown detailing the error
state that has occurred.

We debated whether or not to throw exceptions in a few cases;
ultimately we have decided that error states should be clearly
defined and handled (both for us internally and for users).

What this means is that, in a few cases, our library will `throw`
which results in callers being immediately alerted of the error
state that caused the exception to be thrown (so that errors are
not propagated silently throughout application code).

This is an added layer of _safety_ to help ensure code that depends
on this library remains correct (w.r.t. it's usage of this library).

In short, the validation we are doing here says that callers:
- cannot define negative image `widths`
- cannot define invalid width ranges, e.g. `start > stop`
- cannot define invalid width `tol`erance values, e.g. `0.00001`

We consider these constraints to be reasonable and **empowering**
rather than _limiting_. That is, this kind of validation helps guard
against typos, e.g.