### PR TITLE
docs: reorder install instruction to promote usage of composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,6 @@
 
 ## Installation
 
-### Standalone
-
-Just copy the files to your project, and include the `src/autoload.php` file. We recommend using Composer if at all possible.
-
 ### Using Composer
 
 Define the following requirement in your `composer.json` file:
@@ -46,6 +42,10 @@ Define the following requirement in your `composer.json` file:
 ```
 
 And include the global `vendor/autoload.php` autoloader.
+
+### Standalone
+
+Just copy the files to your project, and include the `src/autoload.php` file. We recommend using Composer if at all possible.
 
 ## Usage
 


### PR DESCRIPTION
Title says it all. I thought putting the standalone instructions underneath the Composer instructions flowed better.