### PR TITLE
fix: dpr srcset when only h param

### DIFF
--- a/src/Imgix/UrlBuilder.php
+++ b/src/Imgix/UrlBuilder.php
@@ -165,7 +165,7 @@ class UrlBuilder {
         // If `params` have a width param or _both_ height and aspect
         // ratio parameters then the srcset to be constructed with
         // these params _is dpr based
-        return $hasWidth || ($hasHeight && $hasAspectRatio);
+        return $hasWidth || $hasHeight;
     }
 
     private function createDPRSrcSet($path, $params, $disableVariableQuality=false) {

--- a/src/Imgix/UrlBuilder.php
+++ b/src/Imgix/UrlBuilder.php
@@ -162,9 +162,8 @@ class UrlBuilder {
         $hasHeight = array_key_exists('h', $params) ? $params['h'] : NULL;
         $hasAspectRatio = array_key_exists('ar', $params) ? $params['ar'] : NULL;
 
-        // If `params` have a width param or _both_ height and aspect
-        // ratio parameters then the srcset to be constructed with
-        // these params _is dpr based
+        // If `params` have a width or height parameter then the
+        // srcset to be constructed with these params _is dpr based
         return $hasWidth || $hasHeight;
     }
 

--- a/tests/Imgix/Tests/UrlBuilderTest.php
+++ b/tests/Imgix/Tests/UrlBuilderTest.php
@@ -398,7 +398,7 @@ https://demos.imgix.net/image.jpg?ixlib=php-3.3.0&w=535 535w';
 
     public function testGivenHeightSrcsetGeneratesPairs() {
         $srcset = $this->srcsetBuilder(array("h"=>300));
-        $expectedNumberOfPairs = 31;
+        $expectedNumberOfPairs = 5;
         $this->assertEquals($expectedNumberOfPairs, count(explode(",", $srcset)));
     }
 
@@ -411,36 +411,48 @@ https://demos.imgix.net/image.jpg?ixlib=php-3.3.0&w=535 535w';
         }
     }
 
-    public function testGivenHeightSrcsetPairsWithinBounds() {
+    public function testHeightBasedSrcsetHasDprValues() {
         $srcset = $this->srcsetBuilder(array("h"=>300));
         $srclist = explode(",", $srcset);
 
-        $minParsed = explode(" ", $srclist[0])[1];
-        $maxParsed = explode(" ", $srclist[count($srclist)-1])[1];
-        $min = $this->parseWidth($minParsed);
-        $max = $this->parseWidth($maxParsed);
-
-        $this->assertGreaterThanOrEqual(100, $min);
-        $this->assertLessThanOrEqual(8192, $max);
-    }
-
-    public function testGivenHeightSrcsetIteratesEighteenPercent() {
-        $incrementAllowed = .18;
-        $srcset = $this->srcsetBuilder(array("h"=>300));
-        $srclist = explode(",", $srcset);
-
-        $widths = array_map(function ($src) {
-            return $this->parseWidth(explode(" ", $src)[1]);
-        }, $srclist);
-
-        $prev = $widths[0];
-        $size = count($widths);
-        for ($i = 1; $i < $size; $i++) {
-            $width = $widths[$i];
-            $this->assertLessThan((1 + $incrementAllowed), ($width / $prev));
-            $prev = $width;
+        foreach ($srclist as $i=>$src) {
+            $dpr = explode(" ", $src)[1];
+            $this->assertMatchesRegularExpression("/x/", $dpr);
         }
     }
+
+    // TODO(luis): remove this, test no longer relevant for h only srcsets
+    // public function testGivenHeightSrcsetPairsWithinBounds() {
+    //     $srcset = $this->srcsetBuilder(array("h"=>300));
+    //     $srclist = explode(",", $srcset);
+
+    //     $minParsed = explode(" ", $srclist[0])[1];
+    //     $maxParsed = explode(" ", $srclist[count($srclist)-1])[1];
+    //     $min = $this->parseWidth($minParsed);
+    //     $max = $this->parseWidth($maxParsed);
+
+    //     $this->assertGreaterThanOrEqual(100, $min);
+    //     $this->assertLessThanOrEqual(8192, $max);
+    // }
+
+    // TODO(luis): remove this, test no longer relevant for h only srcsets
+    // public function testGivenHeightSrcsetIteratesEighteenPercent() {
+    //     $incrementAllowed = .18;
+    //     $srcset = $this->srcsetBuilder(array("h"=>300));
+    //     $srclist = explode(",", $srcset);
+
+    //     $widths = array_map(function ($src) {
+    //         return $this->parseWidth(explode(" ", $src)[1]);
+    //     }, $srclist);
+
+    //     $prev = $widths[0];
+    //     $size = count($widths);
+    //     for ($i = 1; $i < $size; $i++) {
+    //         $width = $widths[$i];
+    //         $this->assertLessThan((1 + $incrementAllowed), ($width / $prev));
+    //         $prev = $width;
+    //     }
+    // }
 
     public function testGivenHeightSrcsetSignsUrls() {
         $srcset = $this->srcsetBuilder(array("h"=>300));

--- a/tests/Imgix/Tests/UrlBuilderTest.php
+++ b/tests/Imgix/Tests/UrlBuilderTest.php
@@ -421,38 +421,15 @@ https://demos.imgix.net/image.jpg?ixlib=php-3.3.0&w=535 535w';
         }
     }
 
-    // TODO(luis): remove this, test no longer relevant for h only srcsets
-    // public function testGivenHeightSrcsetPairsWithinBounds() {
-    //     $srcset = $this->srcsetBuilder(array("h"=>300));
-    //     $srclist = explode(",", $srcset);
+    public function testHeightIncludesDPRParam() {
+        $srcset = $this->srcsetBuilder(array("h"=>300));
+        $srclist = explode(",", $srcset);
 
-    //     $minParsed = explode(" ", $srclist[0])[1];
-    //     $maxParsed = explode(" ", $srclist[count($srclist)-1])[1];
-    //     $min = $this->parseWidth($minParsed);
-    //     $max = $this->parseWidth($maxParsed);
-
-    //     $this->assertGreaterThanOrEqual(100, $min);
-    //     $this->assertLessThanOrEqual(8192, $max);
-    // }
-
-    // TODO(luis): remove this, test no longer relevant for h only srcsets
-    // public function testGivenHeightSrcsetIteratesEighteenPercent() {
-    //     $incrementAllowed = .18;
-    //     $srcset = $this->srcsetBuilder(array("h"=>300));
-    //     $srclist = explode(",", $srcset);
-
-    //     $widths = array_map(function ($src) {
-    //         return $this->parseWidth(explode(" ", $src)[1]);
-    //     }, $srclist);
-
-    //     $prev = $widths[0];
-    //     $size = count($widths);
-    //     for ($i = 1; $i < $size; $i++) {
-    //         $width = $widths[$i];
-    //         $this->assertLessThan((1 + $incrementAllowed), ($width / $prev));
-    //         $prev = $width;
-    //     }
-    // }
+        foreach ($srclist as $i=>$src) {
+            $dpr = explode(" ", $src)[0];
+            $this->assertMatchesRegularExpression("/dpr=/", $dpr);
+        }
+    }
 
     public function testGivenHeightSrcsetSignsUrls() {
         $srcset = $this->srcsetBuilder(array("h"=>300));


### PR DESCRIPTION
# Description
This PR ensures a DPR-based SrcSet is generated when a fixed height is the only parameter value.

It removes tests that no longer apply to only having h as a param, and
adds tests that ensure the DPR `sercset` was generated correctly.