### PR TITLE
chore: update gh pr action

### DIFF
--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -1,4 +1,4 @@
-name: Add needs-review and size/XL pull requests to projects
+name: Add PR to project
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   add-to-project:
-    name: Add issue to project
+    name: Add PR to project
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@v0.3.0


### PR DESCRIPTION
This PR changes the add pr to the project action title to better match what it's doing, adding opened PRs to the GH project board.

You can see the Action take place bellow with the updated information.