### PR TITLE
test: add missing tests for 100% coverage

### DIFF
--- a/src/UrlBuilder.php
+++ b/src/UrlBuilder.php
@@ -124,7 +124,7 @@ class UrlBuilder {
         $stop=self::MAX_WIDTH,
         $tol=self::SRCSET_WIDTH_TOLERANCE) {
 
-        if ($start == $stop) {
+        if ($start === $stop) {
             return array((int) $start);
         }
 

--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -68,7 +68,7 @@ class UrlHelper {
             ksort($this->params);
 
             foreach ($this->params as $key => $val) {
-                if (substr($key, -2) == '64') {
+                if (substr($key, -2) === '64') {
                     $encodedVal = self::base64url_encode($val);
                 } else {
                     $encodedVal = is_array($val) ? rawurlencode(implode(',',$val)) : rawurlencode($val);

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -47,7 +47,7 @@ class Validator {
             throw new \InvalidArgumentException("`widths` array cannot be `null`");
         }
 
-        if (count($widths) == 0) {
+        if (count($widths) === 0) {
             throw new \InvalidArgumentException("`widths` array cannot be empty");
         }
         foreach ($widths as &$w) {

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -43,7 +43,7 @@ class Validator {
     }
 
     public static function validateWidths($widths) {
-        if ($widths == NULL) {
+        if (is_null($widths)) {
             throw new \InvalidArgumentException("`widths` array cannot be `null`");
         }
 

--- a/tests/UrlHelperTest.php
+++ b/tests/UrlHelperTest.php
@@ -8,6 +8,14 @@ use PHPUnit\Framework\TestCase;
 class UrlHelperTest extends TestCase {
 
     /*--- formatPath() ---*/
+    public function testHelperFormatPathWithNoPath()
+    {
+        $path = '';
+        $uh = new URLHelper('test.imgix.net', $path);
+
+        $this->assertEquals($uh->formatPath($path), '/'.$path);
+    }
+
     public function testHelperFormatPathWithSimplePath() {
         $path = "dog.jpg";
         $uh = new URLHelper("test.imgix.net", $path);
@@ -118,5 +126,21 @@ class UrlHelperTest extends TestCase {
         $uh = new URLHelper("imgix-library-secure-test-source.imgix.net", "dog.jpg", "https", "EHFQXiZhxP4wA2c4");
         $uh->setParameter("w", 500);
         $this->assertEquals("https://imgix-library-secure-test-source.imgix.net/dog.jpg?w=500&s=e4eb402d12bbdf267bf0fc5588170d56", $uh->getURL());
+    }
+
+    public function testHelperBuildSignedURLWithNullHashSetterParams() {
+        $uh = new URLHelper("imgix-library-secure-test-source.imgix.net", "dog.jpg", "https", "EHFQXiZhxP4wA2c4");
+        $uh->setParameter("w", 500);
+        $this->assertEquals("https://imgix-library-secure-test-source.imgix.net/dog.jpg?w=500&s=e4eb402d12bbdf267bf0fc5588170d56", $uh->getURL());
+        $uh->setParameter("w", NULL);
+        $this->assertEquals("https://imgix-library-secure-test-source.imgix.net/dog.jpg?s=2b0bc99b1042e3c1c9aae6598acc3def", $uh->getURL());
+    }
+
+    public function testHelperBuildSignedURLWithHashDeleterParams() {
+        $uh = new URLHelper("imgix-library-secure-test-source.imgix.net", "dog.jpg", "https", "EHFQXiZhxP4wA2c4");
+        $uh->setParameter("w", 500);
+        $this->assertEquals("https://imgix-library-secure-test-source.imgix.net/dog.jpg?w=500&s=e4eb402d12bbdf267bf0fc5588170d56", $uh->getURL());
+        $uh->deleteParameter("w");
+        $this->assertEquals("https://imgix-library-secure-test-source.imgix.net/dog.jpg?s=2b0bc99b1042e3c1c9aae6598acc3def", $uh->getURL());
     }
 }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -63,4 +63,13 @@ class ValidatorTest extends TestCase {
         $this->expectException(InvalidArgumentException::class);
         Validator::validateWidths([]);
     }
+
+    /**
+     * Test `validateWidths` throws if passed negative values.
+     */
+    public function testValidateWidthsNegativeValues()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        Validator::validateWidths([0, -1, 100]);
+    }
 }


### PR DESCRIPTION
## Description

Adds 3 tests to `UrlHelperTest.php` and 1 test to `ValidatorTest.php`. These tests brings the code base to 100% coverage.

### testHelperFormatPathWithNoPath

Touches this piece of code in `UrlHelper.php`:

```php
22 if (!is_string($path) || strlen($path) < 1)
23     return '/';
```

### testHelperBuildSignedURLWithNullHashSetterParams & testHelperBuildSignedURLWithHashDeleterParams

Tests that unsetting parameters via `setParameter()` and `deleteParameter()` in `UrlHelper.php` works. It tests by first setting a value, and then either setting it to `null` or by using `deleteParameter()`.

---

### testValidateWidthsNegativeValues

Tests that negative values throws an exception in `validateWidths()`.

The `$widths == NULL` on line 46 in `Validator.php` actually was truthy if `$widths` was an empty array.

`testValidateWidthsEmptyArray()` did therefore pass, but not for the right reason. It was passing because of the loose comparison in $widths == NULL was throwing the exception.

Link that shows the comparisons in action: ~~https://3v4l.org/pWMCv~~ 
Clearer example: https://3v4l.org/JhR03

---

### Changes to the code

The switch to strict comparisons (`==` to `===`) just makes the code more "safe" by checking type as well as value.
The switch to `is_null()` in `validateWidths()` makes the code work as expected.

## Before this PR

Run `$ phpunit --coverage-text`. Needs XDebug installed.

```
Code Coverage Report:      
  2023-01-20 14:41:09      

 Summary:
  Classes: 33.33% (1/3)    
  Methods: 83.33% (20/24)  
  Lines:   95.62% (131/137)

Imgix\UrlBuilder
  Methods: 100.00% (11/11)   Lines: 100.00% ( 73/ 73)
Imgix\UrlHelper
  Methods:  57.14% ( 4/ 7)   Lines:  90.91% ( 40/ 44)
Imgix\Validator
  Methods:  83.33% ( 5/ 6)   Lines:  90.00% ( 18/ 20)
```

## After this PR

Run `$ phpunit --coverage-text`. Needs XDebug installed.

```
Code Coverage Report:       
  2023-01-20 14:42:11       
                            
 Summary:                   
  Classes: 100.00% (3/3)    
  Methods: 100.00% (24/24)  
  Lines:   100.00% (137/137)

Imgix\UrlBuilder
  Methods: 100.00% (11/11)   Lines: 100.00% ( 73/ 73)
Imgix\UrlHelper
  Methods: 100.00% ( 7/ 7)   Lines: 100.00% ( 44/ 44)
Imgix\Validator
  Methods: 100.00% ( 6/ 6)   Lines: 100.00% ( 20/ 20)
```

## Checklist

- [x] Read the [contributing guidelines](CONTRIBUTING.md).
- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec format.
- [x] All existing unit tests are still passing.

- [x] Add new passing unit tests to cover the code introduced by your PR.
