### PR TITLE
test: set package version as const

### DIFF
--- a/tests/UrlBuilderTest.php
+++ b/tests/UrlBuilderTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class UrlBuilderTest extends TestCase
 {
+    public const PACKAGE_VERSION = '4.0.0';
     public const TARGET_WIDTHS = [
         100, 116, 135, 156, 181, 210, 244, 283,
         328, 380, 441, 512, 594, 689, 799, 927,
@@ -135,10 +136,9 @@ class UrlBuilderTest extends TestCase
     {
         $builder = new UrlBuilder('demos.imgix.net', true);
         $url = $builder->createUrl('https://my-demo-site.com/files/133467012/avatar icon.png?some=chill&params=1');
-        $composerFileJson = json_decode(file_get_contents('./composer.json'), true);
-        $version = $composerFileJson['version'];
+        // $composerFileJson = json_decode(file_get_contents('./composer.json'), true);
 
-        $this->assertEquals('https://demos.imgix.net/https%3A%2F%2Fmy-demo-site.com%2Ffiles%2F133467012%2Favatar%20icon.png%3Fsome%3Dchill%26params%3D1?ixlib=php-'.$version, $url);
+        $this->assertEquals('https://demos.imgix.net/https%3A%2F%2Fmy-demo-site.com%2Ffiles%2F133467012%2Favatar%20icon.png%3Fsome%3Dchill%26params%3D1?ixlib=php-'. self::PACKAGE_VERSION, $url);
     }
 
     public function testNestedParameters()
@@ -242,7 +242,7 @@ class UrlBuilderTest extends TestCase
         $builder = new UrlBuilder("demos.imgix.net", true, false);
         $opts = array('start' => 328, 'stop' => 328);
         $actual = $builder->createSrcSet($path="image.jpg", $params=array(), $options=$opts);
-        $expected = 'https://demos.imgix.net/image.jpg?ixlib=php-4.0.0&w=328 328w';
+        $expected = 'https://demos.imgix.net/image.jpg?ixlib=php-'. self::PACKAGE_VERSION . '&w=328 328w';
         $this->assertEquals($expected, $actual);
 
         $builder = new UrlBuilder('demos.imgix.net', true, false);
@@ -251,16 +251,15 @@ class UrlBuilderTest extends TestCase
             $params = [],
             $options = ['start' => 720, 'stop' => 720]
         );
-
-        $expected = 'https://demos.imgix.net/image.jpg?ixlib=php-4.0.0&w=720 720w';
+        $expected = 'https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION . '&w=720 720w';
         $this->assertEquals($expected, $actual);
 
         $builder = new UrlBuilder('demos.imgix.net', true, false);
         $opts = ['start' => 640, 'stop' => 720];
         $actual = $builder->createSrcSet($path = 'image.jpg', $params = [], $options = $opts);
         $expected = // Raw string literal
-'https://demos.imgix.net/image.jpg?ixlib=php-4.0.0&w=640 640w,
-https://demos.imgix.net/image.jpg?ixlib=php-4.0.0&w=720 720w';
+'https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION .'&w=640 640w,
+https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION . '&w=720 720w';
 
         $this->assertEquals($expected, $actual);
 
@@ -269,11 +268,11 @@ https://demos.imgix.net/image.jpg?ixlib=php-4.0.0&w=720 720w';
         $opts = ['start' => 100, 'stop' => 108, 'tol' => 0.01];
         $actual = $builder->createSrcSet($path = 'image.jpg', $params = [], $options = $opts);
         $expected = // Raw string literal
-'https://demos.imgix.net/image.jpg?ixlib=php-4.0.0&w=100 100w,
-https://demos.imgix.net/image.jpg?ixlib=php-4.0.0&w=102 102w,
-https://demos.imgix.net/image.jpg?ixlib=php-4.0.0&w=104 104w,
-https://demos.imgix.net/image.jpg?ixlib=php-4.0.0&w=106 106w,
-https://demos.imgix.net/image.jpg?ixlib=php-4.0.0&w=108 108w';
+'https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION . '&w=100 100w,
+https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION . '&w=102 102w,
+https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION . '&w=104 104w,
+https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION . '&w=106 106w,
+https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION . '&w=108 108w';
 
         $this->assertEquals($expected, $actual);
     }
@@ -323,11 +322,11 @@ https://demos.imgix.net/image.jpg?ixlib=php-4.0.0&w=108 108w';
             $params = ['w' => 640, 'q' => 100]
         );
         $expected =
-'https://demos.imgix.net/image.jpg?dpr=1&ixlib=php-4.0.0&q=100&w=640 1x,
-https://demos.imgix.net/image.jpg?dpr=2&ixlib=php-4.0.0&q=100&w=640 2x,
-https://demos.imgix.net/image.jpg?dpr=3&ixlib=php-4.0.0&q=100&w=640 3x,
-https://demos.imgix.net/image.jpg?dpr=4&ixlib=php-4.0.0&q=100&w=640 4x,
-https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-4.0.0&q=100&w=640 5x';
+'https://demos.imgix.net/image.jpg?dpr=1&ixlib=php-' . self::PACKAGE_VERSION .'&q=100&w=640 1x,
+https://demos.imgix.net/image.jpg?dpr=2&ixlib=php-' . self::PACKAGE_VERSION .'&q=100&w=640 2x,
+https://demos.imgix.net/image.jpg?dpr=3&ixlib=php-' . self::PACKAGE_VERSION .'&q=100&w=640 3x,
+https://demos.imgix.net/image.jpg?dpr=4&ixlib=php-' . self::PACKAGE_VERSION .'&q=100&w=640 4x,
+https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-' . self::PACKAGE_VERSION .'&q=100&w=640 5x';
         $this->assertEquals($expected, $actual);
     }
 
@@ -336,13 +335,12 @@ https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-4.0.0&q=100&w=640 5x';
     {
         $builder = new UrlBuilder('demos.imgix.net', true, false);
         $actual = $builder->createSrcSet($path = 'image.jpg', $params = ['w' => 740]);
-
         $expected =
-'https://demos.imgix.net/image.jpg?dpr=1&ixlib=php-4.0.0&q=75&w=740 1x,
-https://demos.imgix.net/image.jpg?dpr=2&ixlib=php-4.0.0&q=50&w=740 2x,
-https://demos.imgix.net/image.jpg?dpr=3&ixlib=php-4.0.0&q=35&w=740 3x,
-https://demos.imgix.net/image.jpg?dpr=4&ixlib=php-4.0.0&q=23&w=740 4x,
-https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-4.0.0&q=20&w=740 5x';
+'https://demos.imgix.net/image.jpg?dpr=1&ixlib=php-' . self::PACKAGE_VERSION . '&q=75&w=740 1x,
+https://demos.imgix.net/image.jpg?dpr=2&ixlib=php-' . self::PACKAGE_VERSION . '&q=50&w=740 2x,
+https://demos.imgix.net/image.jpg?dpr=3&ixlib=php-' . self::PACKAGE_VERSION . '&q=35&w=740 3x,
+https://demos.imgix.net/image.jpg?dpr=4&ixlib=php-' . self::PACKAGE_VERSION . '&q=23&w=740 4x,
+https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-' . self::PACKAGE_VERSION . '&q=20&w=740 5x';
         $this->assertEquals($expected, $actual);
     }
 
@@ -353,13 +351,12 @@ https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-4.0.0&q=20&w=740 5x';
         $params = ['w' => 640];
         $opts = ['disableVariableQuality' => true];
         $actual = $builder->createSrcSet($path = 'image.jpg', $params = $params, $opts = $opts);
-
         $expected =
-'https://demos.imgix.net/image.jpg?dpr=1&ixlib=php-4.0.0&w=640 1x,
-https://demos.imgix.net/image.jpg?dpr=2&ixlib=php-4.0.0&w=640 2x,
-https://demos.imgix.net/image.jpg?dpr=3&ixlib=php-4.0.0&w=640 3x,
-https://demos.imgix.net/image.jpg?dpr=4&ixlib=php-4.0.0&w=640 4x,
-https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-4.0.0&w=640 5x';
+'https://demos.imgix.net/image.jpg?dpr=1&ixlib=php-' . self::PACKAGE_VERSION . '&w=640 1x,
+https://demos.imgix.net/image.jpg?dpr=2&ixlib=php-' . self::PACKAGE_VERSION . '&w=640 2x,
+https://demos.imgix.net/image.jpg?dpr=3&ixlib=php-' . self::PACKAGE_VERSION . '&w=640 3x,
+https://demos.imgix.net/image.jpg?dpr=4&ixlib=php-' . self::PACKAGE_VERSION . '&w=640 4x,
+https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-' . self::PACKAGE_VERSION . '&w=640 5x';
         $this->assertEquals($expected, $actual);
     }
 
@@ -371,13 +368,12 @@ https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-4.0.0&w=640 5x';
         $params = ['w' => 540, 'q' => 75];
         $opts = ['disableVariableQuality' => false]; // Enabled.
         $actual = $builder->createSrcSet($path = 'image.jpg', $params, $opts);
-
         $expected =
-'https://demos.imgix.net/image.jpg?dpr=1&ixlib=php-4.0.0&q=75&w=540 1x,
-https://demos.imgix.net/image.jpg?dpr=2&ixlib=php-4.0.0&q=75&w=540 2x,
-https://demos.imgix.net/image.jpg?dpr=3&ixlib=php-4.0.0&q=75&w=540 3x,
-https://demos.imgix.net/image.jpg?dpr=4&ixlib=php-4.0.0&q=75&w=540 4x,
-https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-4.0.0&q=75&w=540 5x';
+'https://demos.imgix.net/image.jpg?dpr=1&ixlib=php-' . self::PACKAGE_VERSION . '&q=75&w=540 1x,
+https://demos.imgix.net/image.jpg?dpr=2&ixlib=php-' . self::PACKAGE_VERSION . '&q=75&w=540 2x,
+https://demos.imgix.net/image.jpg?dpr=3&ixlib=php-' . self::PACKAGE_VERSION . '&q=75&w=540 3x,
+https://demos.imgix.net/image.jpg?dpr=4&ixlib=php-' . self::PACKAGE_VERSION . '&q=75&w=540 4x,
+https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-' . self::PACKAGE_VERSION . '&q=75&w=540 5x';
         $this->assertEquals($expected, $actual);
     }
 
@@ -391,13 +387,12 @@ https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-4.0.0&q=75&w=540 5x';
             $params = ['w' => 440, 'q' => 99],
             $options = $opts
         );
-
         $expected =
-'https://demos.imgix.net/image.jpg?dpr=1&ixlib=php-4.0.0&q=99&w=440 1x,
-https://demos.imgix.net/image.jpg?dpr=2&ixlib=php-4.0.0&q=99&w=440 2x,
-https://demos.imgix.net/image.jpg?dpr=3&ixlib=php-4.0.0&q=99&w=440 3x,
-https://demos.imgix.net/image.jpg?dpr=4&ixlib=php-4.0.0&q=99&w=440 4x,
-https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-4.0.0&q=99&w=440 5x';
+'https://demos.imgix.net/image.jpg?dpr=1&ixlib=php-' . self::PACKAGE_VERSION .'&q=99&w=440 1x,
+https://demos.imgix.net/image.jpg?dpr=2&ixlib=php-' . self::PACKAGE_VERSION .'&q=99&w=440 2x,
+https://demos.imgix.net/image.jpg?dpr=3&ixlib=php-' . self::PACKAGE_VERSION .'&q=99&w=440 3x,
+https://demos.imgix.net/image.jpg?dpr=4&ixlib=php-' . self::PACKAGE_VERSION .'&q=99&w=440 4x,
+https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-' . self::PACKAGE_VERSION .'&q=99&w=440 5x';
         $this->assertEquals($expected, $actual);
     }
 
@@ -407,11 +402,11 @@ https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-4.0.0&q=99&w=440 5x';
         $opts = ['widths' => [100, 200, 303, 404, 535]];
         $actual = $builder->createSrcSet($path = 'image.jpg', $params = [], $options = $opts);
         $expected =
-'https://demos.imgix.net/image.jpg?ixlib=php-4.0.0&w=100 100w,
-https://demos.imgix.net/image.jpg?ixlib=php-4.0.0&w=200 200w,
-https://demos.imgix.net/image.jpg?ixlib=php-4.0.0&w=303 303w,
-https://demos.imgix.net/image.jpg?ixlib=php-4.0.0&w=404 404w,
-https://demos.imgix.net/image.jpg?ixlib=php-4.0.0&w=535 535w';
+'https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION .'&w=100 100w,
+https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION .'&w=200 200w,
+https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION .'&w=303 303w,
+https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION .'&w=404 404w,
+https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION .'&w=535 535w';
 
         $this->assertEquals($expected, $actual);
     }


### PR DESCRIPTION
## Description

Anytime the URLBuilder test needed to be updated we had to go into several test cases and manually update the package version number. 

This PR sets the package version as a const that can be references by all the tests