### PR TITLE
refactor: reformat and modernize large parts of the code base

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,8 @@ images on the domains it is provided.
 ```php
 use Imgix\UrlBuilder;
 
-$builder = new UrlBuilder("demos.imgix.net");
-$params = array("w" => 100, "h" => 100);
-echo $builder->createURL("bridge.png", $params);
+$builder = new UrlBuilder('demos.imgix.net');
+echo $builder->createURL('bridge.png', ['w' => 100, 'h' => 100]);
 // 'https://demos.imgix.net/bridge.png?h=100&w=100'
 ```
 
@@ -52,10 +51,9 @@ HTTPS support is available _by default_. However, if you need HTTP support, call
 ```php
 use Imgix\UrlBuilder;
 
-$builder = new UrlBuilder("demos.imgix.net");
+$builder = new UrlBuilder('demos.imgix.net');
 $builder->setUseHttps(false);
-$params = array("w" => 100, "h" => 100);
-echo $builder->createURL("bridge.png", $params);
+echo $builder->createURL('bridge.png', ['w' => 100, 'h' => 100]);
 // 'http://demos.imgix.net/bridge.png?h=100&w=100'
 ```
 
@@ -67,11 +65,10 @@ provide your signature key to the URL builder.
 ```php
 use Imgix\UrlBuilder;
 
-$builder = new UrlBuilder("demos.imgix.net");
-$builder->setSignKey("test1234");
-$params = array("w" => 100, "h" => 100);
-echo $builder->createURL("bridge.png", $params);
-// 'http://demos.imgix.net/bridge.png?h=100&w=100&s=bb8f3a2ab832e35997456823272103a4'
+$builder = new UrlBuilder('demos.imgix.net');
+$builder->setSignKey('test1234');
+echo $builder->createURL("bridge.png", ['w' => 100, 'h' => 100]);
+// 'https://demos.imgix.net/bridge.png?h=100&w=100&s=bb8f3a2ab832e35997456823272103a4'
 ```
 
 ## Srcset Generation
@@ -79,8 +76,8 @@ echo $builder->createURL("bridge.png", $params);
 The imgix-php package allows for generation of custom srcset attributes, which can be invoked through the `createSrcSet` method. By default, the generated srcset will allow for responsive size switching by building a list of image-width mappings.
 
 ```php
-$builder = new UrlBuilder("demos.imgix.net", true, "my-key", false);
-echo $builder->createSrcSet("image.png");
+$builder = new UrlBuilder('demos.imgix.net', true, 'my-key', false);
+echo $builder->createSrcSet('image.png');
 ```
 
 The above will produce the following srcset attribute value which can then be served to the client:
@@ -101,18 +98,18 @@ In cases where enough information is provided about an image's dimensions, `crea
 By invoking `createSrcSet` with either a width **or** height provided, a different srcset will be generated for a fixed-width image instead.
 
 ```php
-$builder = new UrlBuilder("demos.imgix.net", true, "my-key", false);
-echo $builder->createSrcSet("image.png", array("h"=>800, "ar"=>"3:2", "fit"=>"crop"));
+$builder = new UrlBuilder('demos.imgix.net', true, 'my-key', false);
+echo $builder->createSrcSet('image.png', ['h' => 800, 'ar' => '3:2', 'fit' => 'crop']);
 ```
 
 Will produce the following attribute value:
 
 ``` html
-https://demos.imgix.net/image.png?ar=3%3A2&dpr=1&fit=crop&h=800&s=6cf5c443d1eb98bc3d96ea569fcef088 1x,
-https://demos.imgix.net/image.png?ar=3%3A2&dpr=2&fit=crop&h=800&s=d60a61a5f34545922bd8dff4e53a0555 2x,
-https://demos.imgix.net/image.png?ar=3%3A2&dpr=3&fit=crop&h=800&s=590f96aa426f8589eb7e449ebbeb66e7 3x,
-https://demos.imgix.net/image.png?ar=3%3A2&dpr=4&fit=crop&h=800&s=c89c2fd3148957647e86cfc32ba20517 4x,
-https://demos.imgix.net/image.png?ar=3%3A2&dpr=5&fit=crop&h=800&s=3d73af69d78d49eef0f81b4b5d718a2c 5x
+https://demos.imgix.net/image.png?ar=3%3A2&dpr=1&fit=crop&h=800&q=75&s=b6b4a327a9e5a9ce5c9251b736c98633 1x,
+https://demos.imgix.net/image.png?ar=3%3A2&dpr=2&fit=crop&h=800&q=50&s=4f96c2dffa682c081ba9b994c49222cc 2x,
+https://demos.imgix.net/image.png?ar=3%3A2&dpr=3&fit=crop&h=800&q=35&s=7b2a069e769cfeaf9e6dbb4679aea2bc 3x,
+https://demos.imgix.net/image.png?ar=3%3A2&dpr=4&fit=crop&h=800&q=23&s=af185a51455a8e97025728b8f303e038 4x,
+https://demos.imgix.net/image.png?ar=3%3A2&dpr=5&fit=crop&h=800&q=20&s=f010a3d00e54153a36d3c27d9317bf8b 5x
 ```
 
 For more information to better understand srcset, we highly recommend
@@ -129,11 +126,10 @@ This behavior will respect any overriding `q` value passed in as a parameter. Ad
 This behavior specifically occurs when a [fixed-width image](#fixed-width-images) is rendered, for example:
 
 ```php
-// Note that `params=array("w" => 100)` allows `createSrcSet` to _infer_ the creation
+// Note that `['w' => 100]` allows `createSrcSet` to _infer_ the creation
 // of a DPR based srcset attribute for fixed-width images.
-$builder = new UrlBuilder("demos.imgix.net", true, "", false);
-$params = array("w" => 100);
-$srcset = $builder->createSrcSet($path="image.jpg", $params=$params);
+$builder = new UrlBuilder('demos.imgix.net', true, '', false);
+$srcset = $builder->createSrcSet('image.jpg', ['w' => 100]);
 ```
 
 The above will generate a srcset with the following `q` to `dpr` query `params`:
@@ -143,7 +139,7 @@ https://demos.imgix.net/image.jpg?dpr=1&q=75&w=100 1x,
 https://demos.imgix.net/image.jpg?dpr=2&q=50&w=100 2x,
 https://demos.imgix.net/image.jpg?dpr=3&q=35&w=100 3x,
 https://demos.imgix.net/image.jpg?dpr=4&q=23&w=100 4x,
-https://demos.imgix.net/image.jpg?dpr=5&q=20&w=100 5x'
+https://demos.imgix.net/image.jpg?dpr=5&q=20&w=100 5x
 ```
 
 ### Fluid-Width Images
@@ -153,9 +149,8 @@ https://demos.imgix.net/image.jpg?dpr=5&q=20&w=100 5x'
 In situations where specific widths are desired when generating `srcset` pairs, a user can specify them by passing an array of positive integers as `'widths'` within the `$options` array:
 
 ``` php
-$builder = new UrlBuilder("demos.imgix.net", true, "", false);
-$opts = array('widths' => array(144, 240, 320, 446, 640));
-$srcset = $builder->createSrcSet($path="image.jpg", $params=array(), $options=$opts);
+$builder = new UrlBuilder('demos.imgix.net', true, '', false);
+$srcset = $builder->createSrcSet('image.jpg', [], ['widths' => [144, 240, 320, 446, 640]]);
 ```
 
 ```html
@@ -175,25 +170,24 @@ Additionally, if both `widths` and a width `tol`erance are passed to the `create
 In certain circumstances, you may want to limit the minimum or maximum value of the non-fixed `srcset` generated by the `createSrcSet` method. To do this, you can specify the widths at which a srcset should `start` and `stop`:
 
 ```php
-$builder = new UrlBuilder("demo.imgix.net", true, "", false);
-$opts = array('start' => 500, 'stop' => 2000);
-$srcset = $builder->createSrcSet($path="image.jpg", $params=array(), $options=$opts);
+$builder = new UrlBuilder('demos.imgix.net', true, '', false);
+$srcset = $builder->createSrcSet('image.jpg', [], ['start' => 500, 'stop' => 2000]);
 ```
 
 Formatted version of the above srcset attribute:
 
 ``` html
-https://demo.imgix.net/image.jpg?w=500 500w,
-https://demo.imgix.net/image.jpg?w=580 580w,
-https://demo.imgix.net/image.jpg?w=673 673w,
-https://demo.imgix.net/image.jpg?w=780 780w,
-https://demo.imgix.net/image.jpg?w=905 905w,
-https://demo.imgix.net/image.jpg?w=1050 1050w,
-https://demo.imgix.net/image.jpg?w=1218 1218w,
-https://demo.imgix.net/image.jpg?w=1413 1413w,
-https://demo.imgix.net/image.jpg?w=1639 1639w,
-https://demo.imgix.net/image.jpg?w=1901 1901w,
-https://demo.imgix.net/image.jpg?w=2000 2000w
+https://demos.imgix.net/image.jpg?w=500 500w,
+https://demos.imgix.net/image.jpg?w=580 580w,
+https://demos.imgix.net/image.jpg?w=673 673w,
+https://demos.imgix.net/image.jpg?w=780 780w,
+https://demos.imgix.net/image.jpg?w=905 905w,
+https://demos.imgix.net/image.jpg?w=1050 1050w,
+https://demos.imgix.net/image.jpg?w=1218 1218w,
+https://demos.imgix.net/image.jpg?w=1413 1413w,
+https://demos.imgix.net/image.jpg?w=1639 1639w,
+https://demos.imgix.net/image.jpg?w=1901 1901w,
+https://demos.imgix.net/image.jpg?w=2000 2000w
 ```
 
 #### Width Tolerance
@@ -207,32 +201,32 @@ A lower tolerance means images will render closer to their native size (thereby 
 By default, srcset width `tol`erance is set to 8 percent, which we consider to be the ideal rate for maximizing cache hits without sacrificing visual quality. Users can specify their own width tolerance by providing a positive scalar value as width `tol`erance:
 
 ```php
-$builder = new UrlBuilder("demo.imgix.net", true, "", false);
-$opts = array('start' => 100, 'stop' => 384, 'tol' => 0.20);
-$srcset = $builder->createSrcSet($path="image.jpg", $params=array(), $options=$opts);
+$builder = new UrlBuilder('demos.imgix.net', true, '', false);
+$srcset = $builder->createSrcSet('image.jpg', [], ['start' => 100, 'stop' => 384, 'tol' => 0.20]);
 ```
 
 In this case, the width `tol`erance is set to 20 percent, which will be reflected in the difference between subsequent widths in a srcset pair:
 
 ```html
-https://demo.imgix.net/image.jpg?w=100 100w,
-https://demo.imgix.net/image.jpg?w=140 140w,
-https://demo.imgix.net/image.jpg?w=196 196w,
-https://demo.imgix.net/image.jpg?w=274 274w,
-https://demo.imgix.net/image.jpg?w=384 384w
+https://demos.imgix.net/image.jpg?w=100 100w,
+https://demos.imgix.net/image.jpg?w=140 140w,
+https://demos.imgix.net/image.jpg?w=196 196w,
+https://demos.imgix.net/image.jpg?w=274 274w,
+https://demos.imgix.net/image.jpg?w=384 384w
 ```
 
 ## The `ixlib` Parameter
 
 For security and diagnostic purposes, we sign all requests with the language and version of library used to generate the URL.
 
-This can be disabled by setting `setIncludeLibraryParam` to `False` like so:
+This can be disabled by setting `setIncludeLibraryParam` to `false` like so:
 
 ``` php
-$builder = new UrlBuilder("demo.imgix.net", true, "", false);
-// Or by calling `setIncludeLibraryParam`
+$builder = new UrlBuilder('demos.imgix.net', true, '', false);
+// Or by calling `setIncludeLibraryParam()`
 $builder->setIncludeLibraryParam(false);
 ```
 
 ## License
+
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fimgix%2Fimgix-php.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fimgix%2Fimgix-php?ref=badge_large)

--- a/src/UrlBuilder.php
+++ b/src/UrlBuilder.php
@@ -80,31 +80,26 @@ class UrlBuilder
 
     public function createSrcSet($path, $params = [], $options = [])
     {
-        $widthsArray = isset($options['widths']) ? $options['widths'] : null;
+        $widthsArray = $options['widths'] ?? null;
 
-        if (isset($widthsArray)) {
+        if (! is_null($widthsArray)) {
             Validator::validateWidths($widthsArray);
 
-            return $this->createSrcSetPairs($path, $params = $params, $widthsArray);
+            return $this->createSrcSetPairs($path, $params, $widthsArray);
         }
-
-        $_start = isset($options['start']) ? $options['start'] : self::MIN_WIDTH;
-        $_stop = isset($options['stop']) ? $options['stop'] : self::MAX_WIDTH;
-        $_tol = isset($options['tol']) ? $options['tol'] : self::SRCSET_WIDTH_TOLERANCE;
-        $_disableVariableQuality = isset($options['disableVariableQuality'])
-                ? $options['disableVariableQuality'] : false;
 
         if ($this->isDpr($params)) {
-            return $this->createDPRSrcSet(
-                $path = $path,
-                $params = $params,
-                $disableVariableQuality = $_disableVariableQuality
-            );
-        } else {
-            $targets = $this->targetWidths($start = $_start, $stop = $_stop, $tol = $_tol);
+            $disableVariableQuality = $options['disableVariableQuality'] ?? false;
 
-            return $this->createSrcSetPairs($path, $params = $params, $targets = $targets);
+            return $this->createDPRSrcSet($path, $params, $disableVariableQuality);
         }
+
+        $start = $options['start'] ?? self::MIN_WIDTH;
+        $stop = $options['stop'] ?? self::MAX_WIDTH;
+        $tol = $options['tol'] ?? self::SRCSET_WIDTH_TOLERANCE;
+        $targets = $this->targetWidths($start, $stop, $tol);
+
+        return $this->createSrcSetPairs($path, $params, $targets);
     }
 
     /**

--- a/src/UrlBuilder.php
+++ b/src/UrlBuilder.php
@@ -161,7 +161,6 @@ class UrlBuilder
 
         $hasWidth = array_key_exists('w', $params) ? $params['w'] : null;
         $hasHeight = array_key_exists('h', $params) ? $params['h'] : null;
-        $hasAspectRatio = array_key_exists('ar', $params) ? $params['ar'] : null;
 
         // If `params` have a width or height parameter then the
         // srcset to be constructed with these params _is dpr based

--- a/src/UrlBuilder.php
+++ b/src/UrlBuilder.php
@@ -163,8 +163,7 @@ class UrlBuilder
     private function isDpr($params)
     {
         if (empty($params)) {
-            // If the params array is empty, then
-            // it is _not_ dpr based.
+            // If the params array is empty, then it is _not_ dpr based.
             return false;
         }
 

--- a/src/UrlBuilder.php
+++ b/src/UrlBuilder.php
@@ -2,6 +2,8 @@
 
 namespace Imgix;
 
+use InvalidArgumentException;
+
 class UrlBuilder
 {
     private $currentVersion = "4.1.0";
@@ -34,7 +36,7 @@ class UrlBuilder
     public function __construct($domain, $useHttps = true, $signKey = '', $includeLibraryParam = true)
     {
         if (! is_string($domain)) {
-            throw new \InvalidArgumentException('UrlBuilder must be passed a string domain');
+            throw new InvalidArgumentException('UrlBuilder must be passed a string domain');
         }
 
         $this->domain = $domain;
@@ -50,9 +52,7 @@ class UrlBuilder
         $DOMAIN_PATTERN = "/^(?:[a-z\d\-_]{1,62}\.){0,125}(?:[a-z\d](?:\-(?=\-*[a-z\d])|[a-z]|\d){0,62}\.)[a-z\d]{1,63}$/";
 
         if (! preg_match($DOMAIN_PATTERN, $domain)) {
-            throw new \InvalidArgumentException('Domain must be passed in as fully-qualified '.
-            'domain name and should not include a protocol or any path element, i.e. '.
-            '"example.imgix.net".');
+            throw new InvalidArgumentException('Domain must be passed in as fully-qualified domain name and should not include a protocol or any path element, i.e. "example.imgix.net".');
         }
     }
 

--- a/src/UrlBuilder.php
+++ b/src/UrlBuilder.php
@@ -6,7 +6,6 @@ use InvalidArgumentException;
 
 class UrlBuilder
 {
-    private $currentVersion = "4.1.0";
     private $domain;
 
     private $useHttps;
@@ -14,6 +13,7 @@ class UrlBuilder
     private $signKey;
 
     private $includeLibraryParam = true;
+    public const VERSION = '4.1.0';
 
     public const TARGET_WIDTHS = [
         100, 116, 134, 156, 182, 210, 244, 282,
@@ -78,7 +78,7 @@ class UrlBuilder
         $domain = $this->domain;
 
         if ($this->includeLibraryParam) {
-            $params['ixlib'] = 'php-'.$this->currentVersion;
+            $params['ixlib'] = 'php-'.static::VERSION;
         }
 
         $uh = new UrlHelper($domain, $path, $scheme, $this->signKey, $params);

--- a/src/UrlBuilder.php
+++ b/src/UrlBuilder.php
@@ -19,7 +19,8 @@ class UrlBuilder
         100, 116, 134, 156, 182, 210, 244, 282,
         328, 380, 442, 512, 594, 688, 798, 926,
         1074, 1246, 1446, 1678, 1946, 2258, 2618,
-        3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192];
+        3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192,
+    ];
 
     // define class constants
     // should be private; but visibility modifiers are not supported php version <7.1
@@ -133,12 +134,12 @@ class UrlBuilder
      * @return int[] $resolutions An array of integer values.
      */
     public function targetWidths(
-        $start=self::MIN_WIDTH,
-        $stop=self::MAX_WIDTH,
-        $tol=self::SRCSET_WIDTH_TOLERANCE
+        $start = self::MIN_WIDTH,
+        $stop = self::MAX_WIDTH,
+        $tol = self::SRCSET_WIDTH_TOLERANCE
     ) {
         if ($start === $stop) {
-            return array((int) $start);
+            return [(int) $start];
         }
 
         Validator::validateMinMaxTol($start, $stop, $tol);

--- a/src/UrlBuilder.php
+++ b/src/UrlBuilder.php
@@ -164,38 +164,35 @@ class UrlBuilder
 
     private function createDPRSrcSet($path, $params, $disableVariableQuality = false)
     {
-        $srcset = '';
+        $srcset = [];
 
-        $size = count(self::TARGET_RATIOS);
-        for ($i = 0; $i < $size; $i++) {
+        foreach (self::DPR_QUALITIES as $dpr => $quality) {
             $currentParams = $params;
-            $currentParams['dpr'] = $i + 1;
-            $currentRatio = self::TARGET_RATIOS[$i];
+            $currentParams['dpr'] = $dpr;
+
             // If variable quality output has been disabled _and_
             // the `q` param _has not_ been passed:
             if (! $disableVariableQuality && ! isset($params['q'])) {
-                $currentParams['q'] = self::DPR_QUALITIES[$i + 1];
+                $currentParams['q'] = $quality;
             }
-            $srcset .= $this->createURL($path, $currentParams).' '.$currentRatio."x,\n";
+
+            $srcset[] = $this->createURL($path, $currentParams).' '.$dpr.'x';
         }
 
-        return substr($srcset, 0, strlen($srcset) - 2);
+        return implode(",\n", $srcset);
     }
 
     private function createSrcSetPairs($path, $params, $targets = self::TARGET_WIDTHS)
     {
-        $srcset = '';
-        $currentWidth = null;
-        $currentParams = null;
+        $srcset = [];
 
-        $size = count($targets);
-        for ($i = 0; $i < $size; $i++) {
-            $currentWidth = $targets[$i];
+        foreach ($targets as $currentWidth) {
             $currentParams = $params;
             $currentParams['w'] = $currentWidth;
-            $srcset .= $this->createURL($path, $currentParams).' '.$currentWidth."w,\n";
+
+            $srcset[] = $this->createURL($path, $currentParams).' '.$currentWidth.'w';
         }
 
-        return substr($srcset, 0, strlen($srcset) - 2);
+        return implode(",\n", $srcset);
     }
 }

--- a/src/UrlBuilder.php
+++ b/src/UrlBuilder.php
@@ -56,14 +56,14 @@ class UrlBuilder
         }
     }
 
-    public function setSignKey($key)
-    {
-        $this->signKey = $key;
-    }
-
     public function setUseHttps($useHttps)
     {
         $this->useHttps = $useHttps;
+    }
+
+    public function setSignKey($key)
+    {
+        $this->signKey = $key;
     }
 
     public function setIncludeLibraryParam($includeLibraryParam)

--- a/src/UrlBuilder.php
+++ b/src/UrlBuilder.php
@@ -157,7 +157,7 @@ class UrlBuilder
         $hasHeight = $params['h'] ?? null;
 
         // If `params` have a width or height parameter then the
-        // srcset to be constructed with these params _is dpr based
+        // srcset to be constructed with these params _is_ dpr based.
         return $hasWidth || $hasHeight;
     }
 

--- a/src/UrlBuilder.php
+++ b/src/UrlBuilder.php
@@ -179,7 +179,7 @@ class UrlBuilder
                 $currentParams['q'] = $quality;
             }
 
-            $srcset[] = $this->createURL($path, $currentParams).' '.$dpr.'x';
+            $srcset[] = "{$this->createURL($path, $currentParams)} {$dpr}x";
         }
 
         return implode(",\n", $srcset);
@@ -193,7 +193,7 @@ class UrlBuilder
             $currentParams = $params;
             $currentParams['w'] = $currentWidth;
 
-            $srcset[] = $this->createURL($path, $currentParams).' '.$currentWidth.'w';
+            $srcset[] = "{$this->createURL($path, $currentParams)} {$currentWidth}w";
         }
 
         return implode(",\n", $srcset);

--- a/src/UrlBuilder.php
+++ b/src/UrlBuilder.php
@@ -15,11 +15,15 @@ class UrlBuilder
         3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192,
     ];
 
-    // define class constants
-    // should be private; but visibility modifiers are not supported php version <7.1
     public const TARGET_RATIOS = [1, 2, 3, 4, 5];
 
-    public const DPR_QUALITIES = [1 => 75, 2 => 50, 3 => 35, 4 => 23, 5 => 20];
+    public const DPR_QUALITIES = [
+        1 => 75,
+        2 => 50,
+        3 => 35,
+        4 => 23,
+        5 => 20,
+    ];
 
     public const MIN_WIDTH = 100;
 

--- a/src/UrlBuilder.php
+++ b/src/UrlBuilder.php
@@ -42,9 +42,9 @@ class UrlBuilder
 
     private function validateDomain($domain)
     {
-        $DOMAIN_PATTERN = "/^(?:[a-z\d\-_]{1,62}\.){0,125}(?:[a-z\d](?:\-(?=\-*[a-z\d])|[a-z]|\d){0,62}\.)[a-z\d]{1,63}$/";
+        $domainPattern = "/^(?:[a-z\d\-_]{1,62}\.){0,125}(?:[a-z\d](?:\-(?=\-*[a-z\d])|[a-z]|\d){0,62}\.)[a-z\d]{1,63}$/";
 
-        if (! preg_match($DOMAIN_PATTERN, $domain)) {
+        if (! preg_match($domainPattern, $domain)) {
             throw new InvalidArgumentException('Domain must be passed in as fully-qualified domain name and should not include a protocol or any path element, i.e. "example.imgix.net".');
         }
     }

--- a/src/UrlBuilder.php
+++ b/src/UrlBuilder.php
@@ -153,8 +153,8 @@ class UrlBuilder
             return false;
         }
 
-        $hasWidth = array_key_exists('w', $params) ? $params['w'] : null;
-        $hasHeight = array_key_exists('h', $params) ? $params['h'] : null;
+        $hasWidth = $params['w'] ?? null;
+        $hasHeight = $params['h'] ?? null;
 
         // If `params` have a width or height parameter then the
         // srcset to be constructed with these params _is dpr based

--- a/src/UrlBuilder.php
+++ b/src/UrlBuilder.php
@@ -67,13 +67,12 @@ class UrlBuilder
     public function createURL($path, $params = [])
     {
         $scheme = $this->useHttps ? 'https' : 'http';
-        $domain = $this->domain;
 
         if ($this->includeLibraryParam) {
             $params['ixlib'] = 'php-'.static::VERSION;
         }
 
-        $uh = new UrlHelper($domain, $path, $scheme, $this->signKey, $params);
+        $uh = new UrlHelper($this->domain, $path, $scheme, $this->signKey, $params);
 
         return $uh->getURL();
     }

--- a/src/UrlBuilder.php
+++ b/src/UrlBuilder.php
@@ -6,13 +6,6 @@ use InvalidArgumentException;
 
 class UrlBuilder
 {
-    private $domain;
-
-    private $useHttps;
-
-    private $signKey;
-
-    private $includeLibraryParam = true;
     public const VERSION = '4.1.0';
 
     public const TARGET_WIDTHS = [
@@ -34,18 +27,17 @@ class UrlBuilder
 
     public const SRCSET_WIDTH_TOLERANCE = 0.08;
 
-    public function __construct($domain, $useHttps = true, $signKey = '', $includeLibraryParam = true)
-    {
+    public function __construct(
+        private $domain,
+        private $useHttps = true,
+        private $signKey = '',
+        private $includeLibraryParam = true,
+    ) {
         if (! is_string($domain)) {
             throw new InvalidArgumentException('UrlBuilder must be passed a string domain');
         }
 
-        $this->domain = $domain;
         $this->validateDomain($this->domain);
-
-        $this->useHttps = $useHttps;
-        $this->signKey = $signKey;
-        $this->includeLibraryParam = $includeLibraryParam;
     }
 
     private function validateDomain($domain)

--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -4,23 +4,14 @@ namespace Imgix;
 
 class UrlHelper
 {
-    private $domain;
-
-    private $path;
-
-    private $scheme;
-
-    private $signKey;
-
-    private $params;
-
-    public function __construct($domain, $path, $scheme = 'http', $signKey = '', $params = [])
-    {
-        $this->domain = $domain;
+    public function __construct(
+        private $domain,
+        private $path,
+        private $scheme = 'http',
+        private $signKey = '',
+        private $params = [],
+    ) {
         $this->path = $this->formatPath($path);
-        $this->scheme = $scheme;
-        $this->signKey = $signKey;
-        $this->params = $params;
     }
 
     public function formatPath($path)

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -2,6 +2,8 @@
 
 namespace Imgix;
 
+use InvalidArgumentException;
+
 class Validator
 {
     public const ONE_PERCENT = 0.01;
@@ -9,14 +11,14 @@ class Validator
     public static function validateMinWidth($start)
     {
         if ($start < 0) {
-            throw new \InvalidArgumentException('`start` width value must be greater than zero');
+            throw new InvalidArgumentException('`start` width value must be greater than zero');
         }
     }
 
     public static function validateMaxWidth($stop)
     {
-            throw new \InvalidArgumentException('`stop` width value must be greater than zero');
         if ($stop < 0) {
+            throw new InvalidArgumentException('`stop` width value must be greater than zero');
         }
     }
 
@@ -29,7 +31,7 @@ class Validator
 
         // Ensure that the range is valid, ie. `start <= stop`.
         if ($start > $stop) {
-            throw new \InvalidArgumentException('`start` width value must be less than `stop` width value');
+            throw new InvalidArgumentException('`start` width value must be less than `stop` width value');
         }
     }
 
@@ -38,7 +40,7 @@ class Validator
         $msg = '`tol`erance value must be greater than, or equal to one percent, ie. >= 0.01';
 
         if ($tol < self::ONE_PERCENT) {
-            throw new \InvalidArgumentException($msg);
+            throw new InvalidArgumentException($msg);
         }
     }
 
@@ -51,15 +53,15 @@ class Validator
     public static function validateWidths($widths)
     {
         if (is_null($widths)) {
-            throw new \InvalidArgumentException("`widths` array cannot be `null`");
+            throw new InvalidArgumentException('`widths` array cannot be `null`');
         }
 
         if (count($widths) === 0) {
-            throw new \InvalidArgumentException("`widths` array cannot be empty");
+            throw new InvalidArgumentException('`widths` array cannot be empty');
         }
         foreach ($widths as &$w) {
             if ($w < 0) {
-                throw new \InvalidArgumentException('width values in `widths` cannot be negative');
+                throw new InvalidArgumentException('width values in `widths` cannot be negative');
             }
         }
     }

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -13,21 +13,21 @@ class Validator
         }
     }
 
-    public static function validateMaxWidth($end)
+    public static function validateMaxWidth($stop)
     {
-        if ($end < 0) {
             throw new \InvalidArgumentException('`stop` width value must be greater than zero');
+        if ($stop < 0) {
         }
     }
 
     public static function validateRange($start, $stop)
     {
-        // Validate the minimum width, `begin`.
+        // Validate the minimum width, `start`.
         Validator::validateMinWidth($start);
-        // Validate the maximum width, `end`.
+        // Validate the maximum width, `stop`.
         Validator::validateMaxWidth($stop);
 
-        // Ensure that the range is valid, ie. `begin <= end`.
+        // Ensure that the range is valid, ie. `start <= stop`.
         if ($start > $stop) {
             throw new \InvalidArgumentException('`start` width value must be less than `stop` width value');
         }
@@ -42,9 +42,9 @@ class Validator
         }
     }
 
-    public static function validateMinMaxTol($begin, $end, $tol)
+    public static function validateMinMaxTol($start, $stop, $tol)
     {
-        Validator::validateRange($begin, $end);
+        Validator::validateRange($start, $stop);
         Validator::validateTolerance($tol);
     }
 

--- a/tests/PathEncodingTest.php
+++ b/tests/PathEncodingTest.php
@@ -12,31 +12,28 @@ class PathEncodingTest extends TestCase
 
     public function testBracketEncoding()
     {
-        $builder = new UrlBuilder(self::HOST, true, '', false);
+        $builder = new UrlBuilder(self::HOST, includeLibraryParam: false);
+
         $url = $builder->createURL('/ <>[]{}|\\^%.jpg');
-        $this->assertEquals(
-            'https://sdk-test.imgix.net/%20%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg',
-            $url
-        );
+
+        $this->assertEquals('https://sdk-test.imgix.net/%20%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg', $url);
     }
 
     public function testSpecialCharsEncoding()
     {
-        $builder = new UrlBuilder(self::HOST, true, '', false);
+        $builder = new UrlBuilder(self::HOST, includeLibraryParam: false);
+
         $url = $builder->createURL('&$+,:;=?@#.jpg');
-        $this->assertEquals(
-            'https://sdk-test.imgix.net/%26%24%2B%2C:%3B%3D%3F@%23.jpg',
-            $url
-        );
+
+        $this->assertEquals('https://sdk-test.imgix.net/%26%24%2B%2C:%3B%3D%3F@%23.jpg', $url);
     }
 
     public function testUnicodeEncoding()
     {
-        $builder = new UrlBuilder(self::HOST, true, '', false);
+        $builder = new UrlBuilder(self::HOST, includeLibraryParam: false);
+
         $url = $builder->createURL('/ساندویچ.jpg');
-        $this->assertEquals(
-            'https://sdk-test.imgix.net/%D8%B3%D8%A7%D9%86%D8%AF%D9%88%DB%8C%DA%86.jpg',
-            $url
-        );
+
+        $this->assertEquals('https://sdk-test.imgix.net/%D8%B3%D8%A7%D9%86%D8%AF%D9%88%DB%8C%DA%86.jpg', $url);
     }
 }

--- a/tests/ReadMeTest.php
+++ b/tests/ReadMeTest.php
@@ -42,7 +42,7 @@ https://demos.imgix.net/image.jpg?dpr=5&q=20&w=100 5x';
     {
         $builder = new UrlBuilder(self::HOST, true, '', false);
 
-        $actual = $builder->createSrcSet('image.jpg', [], ['widths' => [144, 240 ,320 ,446, 640]]);
+        $actual = $builder->createSrcSet('image.jpg', [], ['widths' => [144, 240, 320, 446, 640]]);
         $expected =
 'https://demos.imgix.net/image.jpg?w=144 144w,
 https://demos.imgix.net/image.jpg?w=240 240w,

--- a/tests/ReadMeTest.php
+++ b/tests/ReadMeTest.php
@@ -7,9 +7,11 @@ use PHPUnit\Framework\TestCase;
 
 class ReadMeTest extends TestCase
 {
-    public function testFixedWithImages()
+    private const HOST = 'demos.imgix.net';
+
+    public function testFixedWidthImages()
     {
-        $builder = new UrlBuilder('demos.imgix.net', true, 'my-key', false);
+        $builder = new UrlBuilder(self::HOST, true, 'my-key', false);
         $actual = $builder->createSrcSet('image.png', ['h' => 800, 'ar' => '3:2', 'fit' => 'crop']);
         $expected =
 'https://demos.imgix.net/image.png?ar=3%3A2&dpr=1&fit=crop&h=800&q=75&s=b6b4a327a9e5a9ce5c9251b736c98633 1x,
@@ -23,9 +25,8 @@ https://demos.imgix.net/image.png?ar=3%3A2&dpr=5&fit=crop&h=800&q=20&s=f010a3d00
 
     public function testFixedWidthVariableQualityEnabled()
     {
-        $builder = new UrlBuilder('demos.imgix.net', true, '', false);
-        $params = ['w' => 100];
-        $actual = $builder->createSrcSet($path = 'image.jpg', $params = $params);
+        $builder = new UrlBuilder(self::HOST, true, '', false);
+        $actual = $builder->createSrcSet('image.jpg', ['w' => 100]);
 
         $expected =
 'https://demos.imgix.net/image.jpg?dpr=1&q=75&w=100 1x,
@@ -33,14 +34,15 @@ https://demos.imgix.net/image.jpg?dpr=2&q=50&w=100 2x,
 https://demos.imgix.net/image.jpg?dpr=3&q=35&w=100 3x,
 https://demos.imgix.net/image.jpg?dpr=4&q=23&w=100 4x,
 https://demos.imgix.net/image.jpg?dpr=5&q=20&w=100 5x';
+
         $this->assertEquals($expected, $actual);
     }
 
     public function testFluidWidthCustomWidths()
     {
-        $builder = new UrlBuilder('demos.imgix.net', true, '', false);
-        $opts = ['widths' => [144, 240, 320, 446, 640]];
-        $actual = $builder->createSrcSet($path = 'image.jpg', $params = [], $options = $opts);
+        $builder = new UrlBuilder(self::HOST, true, '', false);
+
+        $actual = $builder->createSrcSet('image.jpg', [], ['widths' => [144, 240 ,320 ,446, 640]]);
         $expected =
 'https://demos.imgix.net/image.jpg?w=144 144w,
 https://demos.imgix.net/image.jpg?w=240 240w,
@@ -54,36 +56,36 @@ https://demos.imgix.net/image.jpg?w=640 640w';
     public function testFluidWidthRanges()
     {
         // Now test custom tolerances (also within a range).
-        $builder = new UrlBuilder('demo.imgix.net', true, '', false);
-        $opts = ['start' => 500, 'stop' => 2000];
-        $actual = $builder->createSrcSet($path = 'image.jpg', $params = [], $options = $opts);
+        $builder = new UrlBuilder(self::HOST, true, '', false);
+
+        $actual = $builder->createSrcSet('image.jpg', [], ['start' => 500, 'stop' => 2000]);
         $expected =
-'https://demo.imgix.net/image.jpg?w=500 500w,
-https://demo.imgix.net/image.jpg?w=580 580w,
-https://demo.imgix.net/image.jpg?w=673 673w,
-https://demo.imgix.net/image.jpg?w=780 780w,
-https://demo.imgix.net/image.jpg?w=905 905w,
-https://demo.imgix.net/image.jpg?w=1050 1050w,
-https://demo.imgix.net/image.jpg?w=1218 1218w,
-https://demo.imgix.net/image.jpg?w=1413 1413w,
-https://demo.imgix.net/image.jpg?w=1639 1639w,
-https://demo.imgix.net/image.jpg?w=1901 1901w,
-https://demo.imgix.net/image.jpg?w=2000 2000w';
+'https://demos.imgix.net/image.jpg?w=500 500w,
+https://demos.imgix.net/image.jpg?w=580 580w,
+https://demos.imgix.net/image.jpg?w=673 673w,
+https://demos.imgix.net/image.jpg?w=780 780w,
+https://demos.imgix.net/image.jpg?w=905 905w,
+https://demos.imgix.net/image.jpg?w=1050 1050w,
+https://demos.imgix.net/image.jpg?w=1218 1218w,
+https://demos.imgix.net/image.jpg?w=1413 1413w,
+https://demos.imgix.net/image.jpg?w=1639 1639w,
+https://demos.imgix.net/image.jpg?w=1901 1901w,
+https://demos.imgix.net/image.jpg?w=2000 2000w';
 
         $this->assertEquals($expected, $actual);
     }
 
     public function testFluidWidthRangesTolerance()
     {
-        $builder = new UrlBuilder('demo.imgix.net', true, '', false);
-        $opts = ['start' => 100, 'stop' => 384, 'tol' => 0.20];
-        $actual = $builder->createSrcSet($path = 'image.jpg', $params = [], $options = $opts);
+        $builder = new UrlBuilder(self::HOST, true, '', false);
+
+        $actual = $builder->createSrcSet('image.jpg', [], ['start' => 100, 'stop' => 384, 'tol' => 0.20]);
         $expected =
-'https://demo.imgix.net/image.jpg?w=100 100w,
-https://demo.imgix.net/image.jpg?w=140 140w,
-https://demo.imgix.net/image.jpg?w=196 196w,
-https://demo.imgix.net/image.jpg?w=274 274w,
-https://demo.imgix.net/image.jpg?w=384 384w';
+'https://demos.imgix.net/image.jpg?w=100 100w,
+https://demos.imgix.net/image.jpg?w=140 140w,
+https://demos.imgix.net/image.jpg?w=196 196w,
+https://demos.imgix.net/image.jpg?w=274 274w,
+https://demos.imgix.net/image.jpg?w=384 384w';
 
         $this->assertEquals($expected, $actual);
     }

--- a/tests/ReadMeTest.php
+++ b/tests/ReadMeTest.php
@@ -7,11 +7,12 @@ use PHPUnit\Framework\TestCase;
 
 class ReadMeTest extends TestCase
 {
-    private const HOST = 'demos.imgix.net';
+    public const HOST = 'demos.imgix.net';
 
     public function testFixedWidthImages()
     {
         $builder = new UrlBuilder(self::HOST, true, 'my-key', false);
+
         $actual = $builder->createSrcSet('image.png', ['h' => 800, 'ar' => '3:2', 'fit' => 'crop']);
         $expected =
 'https://demos.imgix.net/image.png?ar=3%3A2&dpr=1&fit=crop&h=800&q=75&s=b6b4a327a9e5a9ce5c9251b736c98633 1x,
@@ -25,7 +26,7 @@ https://demos.imgix.net/image.png?ar=3%3A2&dpr=5&fit=crop&h=800&q=20&s=f010a3d00
 
     public function testFixedWidthVariableQualityEnabled()
     {
-        $builder = new UrlBuilder(self::HOST, true, '', false);
+        $builder = new UrlBuilder(self::HOST, includeLibraryParam: false);
         $actual = $builder->createSrcSet('image.jpg', ['w' => 100]);
 
         $expected =
@@ -40,7 +41,7 @@ https://demos.imgix.net/image.jpg?dpr=5&q=20&w=100 5x';
 
     public function testFluidWidthCustomWidths()
     {
-        $builder = new UrlBuilder(self::HOST, true, '', false);
+        $builder = new UrlBuilder(self::HOST, includeLibraryParam: false);
 
         $actual = $builder->createSrcSet('image.jpg', [], ['widths' => [144, 240, 320, 446, 640]]);
         $expected =
@@ -56,7 +57,7 @@ https://demos.imgix.net/image.jpg?w=640 640w';
     public function testFluidWidthRanges()
     {
         // Now test custom tolerances (also within a range).
-        $builder = new UrlBuilder(self::HOST, true, '', false);
+        $builder = new UrlBuilder(self::HOST, includeLibraryParam: false);
 
         $actual = $builder->createSrcSet('image.jpg', [], ['start' => 500, 'stop' => 2000]);
         $expected =
@@ -77,7 +78,7 @@ https://demos.imgix.net/image.jpg?w=2000 2000w';
 
     public function testFluidWidthRangesTolerance()
     {
-        $builder = new UrlBuilder(self::HOST, true, '', false);
+        $builder = new UrlBuilder(self::HOST, includeLibraryParam: false);
 
         $actual = $builder->createSrcSet('image.jpg', [], ['start' => 100, 'stop' => 384, 'tol' => 0.20]);
         $expected =

--- a/tests/UrlBuilderTest.php
+++ b/tests/UrlBuilderTest.php
@@ -13,7 +13,8 @@ class UrlBuilderTest extends TestCase
         100, 116, 135, 156, 181, 210, 244, 283,
         328, 380, 441, 512, 594, 689, 799, 927,
         1075, 1247, 1446, 1678, 1946, 2257, 2619,
-        3038, 3524, 4087, 4741, 5500, 6380, 7401, 8192];
+        3038, 3524, 4087, 4741, 5500, 6380, 7401, 8192,
+    ];
 
     public function testURLBuilderRaisesExceptionOnNoDomain()
     {
@@ -239,10 +240,10 @@ class UrlBuilderTest extends TestCase
     public function testCustomSrcsetPairs()
     {
         // Test custom srcset pairs within ranges.
-        $builder = new UrlBuilder("demos.imgix.net", true, false);
-        $opts = array('start' => 328, 'stop' => 328);
-        $actual = $builder->createSrcSet($path="image.jpg", $params=array(), $options=$opts);
         $expected = 'https://demos.imgix.net/image.jpg?ixlib=php-'. self::PACKAGE_VERSION . '&w=328 328w';
+        $builder = new UrlBuilder('demos.imgix.net', true, false);
+        $opts = ['start' => 328, 'stop' => 328];
+        $actual = $builder->createSrcSet($path = 'image.jpg', $params = [], $options = $opts);
         $this->assertEquals($expected, $actual);
 
         $builder = new UrlBuilder('demos.imgix.net', true, false);

--- a/tests/UrlBuilderTest.php
+++ b/tests/UrlBuilderTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\TestCase;
 
 class UrlBuilderTest extends TestCase
 {
+    public const HOST = 'demos.imgix.net';
+
     public const TARGET_WIDTHS = [
         100, 116, 135, 156, 181, 210, 244, 283,
         328, 380, 441, 512, 594, 689, 799, 927,
@@ -19,96 +21,114 @@ class UrlBuilderTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('UrlBuilder must be passed a string domain');
-        $domain = null;
-        $ub = new URLBuilder($domain);
+
+        new URLBuilder(null);
+    }
+
+    public function test_invalid_domain_append_slash()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Domain must be passed in as fully-qualified domain name and should not include a protocol or any path element, i.e. "example.imgix.net".');
+
+        new UrlBuilder(self::HOST.'/');
+    }
+
+    public function test_invalid_domain_prepend_scheme()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Domain must be passed in as fully-qualified domain name and should not include a protocol or any path element, i.e. "example.imgix.net".');
+
+        new UrlBuilder('https://'.self::HOST);
+    }
+
+    public function test_invalid_domain_append_dash()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Domain must be passed in as fully-qualified domain name and should not include a protocol or any path element, i.e. "example.imgix.net".');
+
+        new UrlBuilder(self::HOST.'-');
     }
 
     public function testExamplePlain()
     {
-        $builder = new UrlBuilder('demos.imgix.net', false, '', false);
+        $builder = new UrlBuilder(self::HOST, false, '', false);
 
-        $params = ['w' => 100, 'h' => 100];
-        $url = $builder->createURL('bridge.png', $params);
+        $url = $builder->createURL('bridge.png', ['w' => 100, 'h' => 100]);
 
         $this->assertEquals('http://demos.imgix.net/bridge.png?h=100&w=100', $url);
     }
 
     public function testExamplePlainUsesHttpsByDefault()
     {
-        // Test default `UrlBuilder` uses https by default.
         // Construct the builder with a `$domain` __only__.
-        $builder = new UrlBuilder('demos.imgix.net');
-        // Use `setIncludeLibraryParam`.
-        $builder->setIncludeLibraryParam(false);
-        // Construct a url in accordance with the other tests.
-        $params = ['w' => 100, 'h' => 100];
-        // Create the url with the specified `$path` and `$params`.
-        $url = $builder->createURL('bridge.png', $params);
+        $builder = new UrlBuilder(self::HOST, includeLibraryParam: false);
+
+        $url = $builder->createURL('bridge.png', ['w' => 100, 'h' => 100]);
+
         $this->assertEquals('https://demos.imgix.net/bridge.png?h=100&w=100', $url);
     }
 
     public function testExamplePlainHttps()
     {
-        $builder = new UrlBuilder('demos.imgix.net', false, '', false);
-
+        $builder = new UrlBuilder(self::HOST, false, '', false);
         $builder->setUseHttps(true);
-        $params = ['w' => 100, 'h' => 100];
-        $url = $builder->createURL('bridge.png', $params);
+
+        $url = $builder->createURL('bridge.png', ['w' => 100, 'h' => 100]);
 
         $this->assertEquals('https://demos.imgix.net/bridge.png?h=100&w=100', $url);
     }
 
     public function testExamplePlainSecure()
     {
-        $builder = new UrlBuilder('demos.imgix.net', false, '', false);
+        $builder = new UrlBuilder(self::HOST, false, '', false);
         $builder->setSignKey('test1234');
-        $params = ['w' => 100, 'h' => 100];
-        $url = $builder->createURL('bridge.png', $params);
+
+        $url = $builder->createURL('bridge.png', ['w' => 100, 'h' => 100]);
 
         $this->assertEquals('http://demos.imgix.net/bridge.png?h=100&w=100&s=bb8f3a2ab832e35997456823272103a4', $url);
     }
 
     public function testParamKeysAreEscaped()
     {
-        $builder = new UrlBuilder('demo.imgix.net', true, '', false);
-        $params = ['hello world' => 'interesting'];
-        $url = $builder->createURL('demo.png', $params);
+        $builder = new UrlBuilder(self::HOST, includeLibraryParam: false);
 
-        $this->assertEquals('https://demo.imgix.net/demo.png?hello%20world=interesting', $url);
+        $url = $builder->createURL('demo.png', ['hello world' => 'interesting']);
+
+        $this->assertEquals('https://demos.imgix.net/demo.png?hello%20world=interesting', $url);
     }
 
     public function testParamValuesAreEscaped()
     {
-        $builder = new UrlBuilder('demo.imgix.net', true, '', false);
-        $params = ['hello_world' => '/foo"><script>alert("hacked")</script><'];
-        $url = $builder->createURL('demo.png', $params);
+        $builder = new UrlBuilder(self::HOST, includeLibraryParam: false);
 
-        $this->assertEquals('https://demo.imgix.net/demo.png?hello_world=%2Ffoo%22%3E%3Cscript%3Ealert%28%22hacked%22%29%3C%2Fscript%3E%3C', $url);
+        $url = $builder->createURL('demo.png', ['hello_world' => '/foo"><script>alert("hacked")</script><']);
+
+        $this->assertEquals('https://demos.imgix.net/demo.png?hello_world=%2Ffoo%22%3E%3Cscript%3Ealert%28%22hacked%22%29%3C%2Fscript%3E%3C', $url);
     }
 
     public function testZeroValue()
     {
-        $builder = new UrlBuilder('demos.imgix.net', true, '', false);
+        $builder = new UrlBuilder(self::HOST, includeLibraryParam: false);
 
-        $params = ['foo' => 0];
-        $url = $builder->createURL('bridge.png', $params);
+        $url = $builder->createURL('bridge.png', ['foo' => 0]);
 
         $this->assertEquals('https://demos.imgix.net/bridge.png?foo=0', $url);
     }
 
     public function testBase64ParamVariantsAreBase64Encoded()
     {
-        $builder = new UrlBuilder('demo.imgix.net', true, '', false);
-        $params = ['txt64' => 'I cannøt belîév∑ it wors! 😱'];
-        $url = $builder->createURL('~text', $params);
+        $builder = new UrlBuilder(self::HOST, includeLibraryParam: false);
 
-        $this->assertEquals('https://demo.imgix.net/~text?txt64=SSBjYW5uw7h0IGJlbMOuw6l24oiRIGl0IHdvcu-jv3MhIPCfmLE', $url);
+        $url = $builder->createURL('~text', ['txt64' => 'I cannøt belîév∑ it wors! 😱']);
+
+        $this->assertEquals('https://demos.imgix.net/~text?txt64=SSBjYW5uw7h0IGJlbMOuw6l24oiRIGl0IHdvcu-jv3MhIPCfmLE', $url);
     }
 
     public function testWithFullyQualifiedUrl()
     {
-        $builder = new UrlBuilder('demos.imgix.net', true, '', false);
+        $builder = new UrlBuilder(self::HOST, includeLibraryParam: false);
         $builder->setSignKey('test1234');
+
         $url = $builder->createUrl('http://media.giphy.com/media/jCMq0p94fgBIk/giphy.gif');
 
         $this->assertEquals('https://demos.imgix.net/http%3A%2F%2Fmedia.giphy.com%2Fmedia%2FjCMq0p94fgBIk%2Fgiphy.gif?s=54c35ea3a066357b06bc553ee9975ec9', $url);
@@ -116,8 +136,9 @@ class UrlBuilderTest extends TestCase
 
     public function testWithFullyQualifiedUrlWithSpaces()
     {
-        $builder = new UrlBuilder('demos.imgix.net', true, '', false);
+        $builder = new UrlBuilder(self::HOST, includeLibraryParam: false);
         $builder->setSignKey('test1234');
+
         $url = $builder->createUrl('https://my-demo-site.com/files/133467012/avatar icon.png');
 
         $this->assertEquals('https://demos.imgix.net/https%3A%2F%2Fmy-demo-site.com%2Ffiles%2F133467012%2Favatar%20icon.png?s=6a1d47f292194cfa7573da0e2bb6b0f4', $url);
@@ -125,8 +146,9 @@ class UrlBuilderTest extends TestCase
 
     public function testWithFullyQualifiedUrlWithParams()
     {
-        $builder = new UrlBuilder('demos.imgix.net', true, '', false);
+        $builder = new UrlBuilder(self::HOST, includeLibraryParam: false);
         $builder->setSignKey('test1234');
+
         $url = $builder->createUrl('https://my-demo-site.com/files/133467012/avatar icon.png?some=chill&params=1');
 
         $this->assertEquals('https://demos.imgix.net/https%3A%2F%2Fmy-demo-site.com%2Ffiles%2F133467012%2Favatar%20icon.png%3Fsome%3Dchill%26params%3D1?s=bbc73c61ebc739337b852ff8423a1da9', $url);
@@ -134,70 +156,37 @@ class UrlBuilderTest extends TestCase
 
     public function testInclusionOfLibraryVersionParam()
     {
-        $builder = new UrlBuilder('demos.imgix.net', true);
+        $builder = new UrlBuilder(self::HOST);
+
         $url = $builder->createUrl('https://my-demo-site.com/files/133467012/avatar icon.png?some=chill&params=1');
 
         $this->assertEquals('https://demos.imgix.net/https%3A%2F%2Fmy-demo-site.com%2Ffiles%2F133467012%2Favatar%20icon.png%3Fsome%3Dchill%26params%3D1?ixlib=php-'.UrlBuilder::VERSION, $url);
+
+        $builder = new UrlBuilder(self::HOST);
+        $builder->setIncludeLibraryParam(false);
+
+        $url = $builder->createUrl('https://my-demo-site.com/files/133467012/avatar icon.png?some=chill&params=1');
+
+        $this->assertEquals('https://demos.imgix.net/https%3A%2F%2Fmy-demo-site.com%2Ffiles%2F133467012%2Favatar%20icon.png%3Fsome%3Dchill%26params%3D1', $url);
     }
 
     public function testNestedParameters()
     {
-        $builder = new UrlBuilder('demos.imgix.net', true, '', false);
-        $params = ['auto' => ['compress', 'format']];
-        $url = $builder->createURL('bridge.png', $params);
+        $builder = new UrlBuilder(self::HOST, includeLibraryParam: false);
+
+        $url = $builder->createURL('bridge.png', ['auto' => ['compress', 'format']]);
 
         $this->assertEquals('https://demos.imgix.net/bridge.png?auto=compress%2Cformat', $url);
     }
 
-    public function test_invalid_domain_append_slash()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Domain must be passed in as fully-qualified '.
-        'domain name and should not include a protocol or any path element, i.e. '.
-        '"example.imgix.net".');
-
-        $builder = new UrlBuilder('demos.imgix.net/', true, '', false);
-    }
-
-    public function test_invalid_domain_prepend_scheme()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Domain must be passed in as fully-qualified '.
-        'domain name and should not include a protocol or any path element, i.e. '.
-        '"example.imgix.net".');
-
-        $builder = new UrlBuilder('https://demos.imgix.net', true, '', false);
-    }
-
-    public function test_invalid_domain_append_dash()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Domain must be passed in as fully-qualified '.
-        'domain name and should not include a protocol or any path element, i.e. '.
-        '"example.imgix.net".');
-
-        $builder = new UrlBuilder('demos.imgix.net-', true, '', false);
-    }
-
-    private function srcsetBuilder($params = [])
-    {
-        $builder = new UrlBuilder('demos.imgix.net', true, 'my-key', false);
-
-        return $builder->createSrcSet('bridge.png', $params);
-    }
-
-    // parse the width as an int, eg "100w" => 100
-    private function parseWidth($width)
-    {
-        return (int) substr($width, 0, strlen($width) - 1);
-    }
-
     public function testSrcsetCustomTargetWidths100to7401()
     {
-        $builder = new UrlBuilder('demos.imgix.net', true, 'my-key', false);
-        $expected = $builder->targetWidths($start = 100, $stop = 7401);
+        $builder = new UrlBuilder(self::HOST, true, 'my-key', false);
+
+        $expected = $builder->targetWidths(100, 7401);
         $actual = array_slice(self::TARGET_WIDTHS, 0, -1);
-        $this->assertEquals(count($expected), count($actual));
+
+        $this->assertCount(count($expected), $actual);
         $this->assertEquals($expected, $actual);
     }
 
@@ -206,67 +195,68 @@ class UrlBuilderTest extends TestCase
         // Test that the correct number of target widths have been
         // generated and that they start and stop within the expected
         // range, inclusively.
-        $builder = new UrlBuilder('demos.imgix.net', true, 'my-key', false);
+        $builder = new UrlBuilder(self::HOST, true, 'my-key', false);
 
         $start = 328;
         $stop = 4087;
         $idx_328 = 8;
         $idx_4087 = 18;
 
-        $expected = $builder->targetWidths($start = $start, $stop = $stop);
+        $expected = $builder->targetWidths($start, $stop);
         $actual = array_slice(self::TARGET_WIDTHS, $idx_328, $idx_4087);
-        $this->assertEquals(count($actual), count($expected));
+
+        $this->assertCount(count($expected), $actual);
         $this->assertEquals($start, $actual[0]);
         $this->assertEquals($stop, end($actual));
     }
 
     public function testTargetWidthsMaxTolerance()
     {
-        $builder = new UrlBuilder('demos.imgix.net', true, 'my-key', false);
-        $expected = [0 => 100, 1 => 8192];
-        $actual = $builder->targetWidths($start = 100, $stop = 8192, $tol = 10000000);
-        $this->assertEquals($expected, $actual);
+        $builder = new UrlBuilder(self::HOST, true, 'my-key', false);
+
+        $widths = $builder->targetWidths(100, 8192, 10_000_000);
+
+        $this->assertEquals([0 => 100, 1 => 8192], $widths);
     }
 
     public function testNoParametersGeneratesSrcsetPairs()
     {
         $srcset = $this->srcsetBuilder();
-        $expectedNumberOfPairs = 31;
-        $this->assertEquals($expectedNumberOfPairs, count(explode(',', $srcset)));
+
+        $this->assertCount(31, explode(',', $srcset));
     }
 
     public function testCustomSrcsetPairs()
     {
         // Test custom srcset pairs within ranges.
-        $builder = new UrlBuilder('demos.imgix.net', true, false);
-        $opts = ['start' => 328, 'stop' => 328];
-        $actual = $builder->createSrcSet($path = 'image.jpg', $params = [], $options = $opts);
+        $builder = new UrlBuilder(self::HOST);
+
+        $actual = $builder->createSrcSet('image.jpg', [], ['start' => 328, 'stop' => 328]);
         $expected = 'https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=328 328w';
+
         $this->assertEquals($expected, $actual);
 
-        $builder = new UrlBuilder('demos.imgix.net', true, false);
-        $actual = $builder->createSrcSet(
-            $path = 'image.jpg',
-            $params = [],
-            $options = ['start' => 720, 'stop' => 720]
-        );
+        $builder = new UrlBuilder(self::HOST);
+
+        $actual = $builder->createSrcSet('image.jpg', [], ['start' => 720, 'stop' => 720]);
         $expected = 'https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=720 720w';
+
         $this->assertEquals($expected, $actual);
 
-        $builder = new UrlBuilder('demos.imgix.net', true, false);
-        $opts = ['start' => 640, 'stop' => 720];
-        $actual = $builder->createSrcSet($path = 'image.jpg', $params = [], $options = $opts);
-        $expected = // Raw string literal
+        $builder = new UrlBuilder(self::HOST);
+
+        $actual = $builder->createSrcSet('image.jpg', [], ['start' => 640, 'stop' => 720]);
+        $expected =
 'https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=640 640w,
 https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=720 720w';
 
         $this->assertEquals($expected, $actual);
 
         // Now test custom tolerances (also within a range).
-        $builder = new UrlBuilder('demos.imgix.net', true, false);
-        $opts = ['start' => 100, 'stop' => 108, 'tol' => 0.01];
-        $actual = $builder->createSrcSet($path = 'image.jpg', $params = [], $options = $opts);
-        $expected = // Raw string literal
+        $builder = new UrlBuilder(self::HOST);
+
+        $actual = $builder->createSrcSet('image.jpg', [], ['start' => 100, 'stop' => 108, 'tol' => 0.01]);
+        $expected =
 'https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=100 100w,
 https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=102 102w,
 https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=104 104w,
@@ -315,47 +305,48 @@ https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=108 108w';
 
     public function testDprSrcsetWithQ100()
     {
-        $builder = new UrlBuilder('demos.imgix.net', true, false);
-        $actual = $builder->createSrcSet(
-            $path = 'image.jpg',
-            $params = ['w' => 640, 'q' => 100]
-        );
+        $builder = new UrlBuilder(self::HOST, includeLibraryParam: false);
+
+        $actual = $builder->createSrcSet('image.jpg', ['w' => 640, 'q' => 100]);
         $expected =
-'https://demos.imgix.net/image.jpg?dpr=1&ixlib=php-'.UrlBuilder::VERSION.'&q=100&w=640 1x,
-https://demos.imgix.net/image.jpg?dpr=2&ixlib=php-'.UrlBuilder::VERSION.'&q=100&w=640 2x,
-https://demos.imgix.net/image.jpg?dpr=3&ixlib=php-'.UrlBuilder::VERSION.'&q=100&w=640 3x,
-https://demos.imgix.net/image.jpg?dpr=4&ixlib=php-'.UrlBuilder::VERSION.'&q=100&w=640 4x,
-https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-'.UrlBuilder::VERSION.'&q=100&w=640 5x';
+'https://demos.imgix.net/image.jpg?dpr=1&q=100&w=640 1x,
+https://demos.imgix.net/image.jpg?dpr=2&q=100&w=640 2x,
+https://demos.imgix.net/image.jpg?dpr=3&q=100&w=640 3x,
+https://demos.imgix.net/image.jpg?dpr=4&q=100&w=640 4x,
+https://demos.imgix.net/image.jpg?dpr=5&q=100&w=640 5x';
+
         $this->assertEquals($expected, $actual);
     }
 
     // Test that variable quality is enabled by default.
     public function testDprSrcsetWithDefaultQuality()
     {
-        $builder = new UrlBuilder('demos.imgix.net', true, false);
-        $actual = $builder->createSrcSet($path = 'image.jpg', $params = ['w' => 740]);
+        $builder = new UrlBuilder(self::HOST, includeLibraryParam: false);
+
+        $actual = $builder->createSrcSet('image.jpg', ['w' => 740]);
         $expected =
-'https://demos.imgix.net/image.jpg?dpr=1&ixlib=php-'.UrlBuilder::VERSION.'&q=75&w=740 1x,
-https://demos.imgix.net/image.jpg?dpr=2&ixlib=php-'.UrlBuilder::VERSION.'&q=50&w=740 2x,
-https://demos.imgix.net/image.jpg?dpr=3&ixlib=php-'.UrlBuilder::VERSION.'&q=35&w=740 3x,
-https://demos.imgix.net/image.jpg?dpr=4&ixlib=php-'.UrlBuilder::VERSION.'&q=23&w=740 4x,
-https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-'.UrlBuilder::VERSION.'&q=20&w=740 5x';
+'https://demos.imgix.net/image.jpg?dpr=1&q=75&w=740 1x,
+https://demos.imgix.net/image.jpg?dpr=2&q=50&w=740 2x,
+https://demos.imgix.net/image.jpg?dpr=3&q=35&w=740 3x,
+https://demos.imgix.net/image.jpg?dpr=4&q=23&w=740 4x,
+https://demos.imgix.net/image.jpg?dpr=5&q=20&w=740 5x';
+
         $this->assertEquals($expected, $actual);
     }
 
     // Test that `disableVariableQuality = true` disables `q` params.
     public function testDprVariableQualityDisabled()
     {
-        $builder = new UrlBuilder('demos.imgix.net', true, false);
-        $params = ['w' => 640];
-        $opts = ['disableVariableQuality' => true];
-        $actual = $builder->createSrcSet($path = 'image.jpg', $params = $params, $opts = $opts);
+        $builder = new UrlBuilder(self::HOST, includeLibraryParam: false);
+
+        $actual = $builder->createSrcSet('image.jpg', ['w' => 640], ['disableVariableQuality' => true]);
         $expected =
-'https://demos.imgix.net/image.jpg?dpr=1&ixlib=php-'.UrlBuilder::VERSION.'&w=640 1x,
-https://demos.imgix.net/image.jpg?dpr=2&ixlib=php-'.UrlBuilder::VERSION.'&w=640 2x,
-https://demos.imgix.net/image.jpg?dpr=3&ixlib=php-'.UrlBuilder::VERSION.'&w=640 3x,
-https://demos.imgix.net/image.jpg?dpr=4&ixlib=php-'.UrlBuilder::VERSION.'&w=640 4x,
-https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-'.UrlBuilder::VERSION.'&w=640 5x';
+'https://demos.imgix.net/image.jpg?dpr=1&w=640 1x,
+https://demos.imgix.net/image.jpg?dpr=2&w=640 2x,
+https://demos.imgix.net/image.jpg?dpr=3&w=640 3x,
+https://demos.imgix.net/image.jpg?dpr=4&w=640 4x,
+https://demos.imgix.net/image.jpg?dpr=5&w=640 5x';
+
         $this->assertEquals($expected, $actual);
     }
 
@@ -363,49 +354,46 @@ https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-'.UrlBuilder::VERSION.'&w=640 
     // `disableVariableQuality = false`.
     public function testDprSrcsetQOverridesEnabledVariableQuality()
     {
-        $builder = new UrlBuilder('demos.imgix.net', true, false);
-        $params = ['w' => 540, 'q' => 75];
-        $opts = ['disableVariableQuality' => false]; // Enabled.
-        $actual = $builder->createSrcSet($path = 'image.jpg', $params, $opts);
+        $builder = new UrlBuilder(self::HOST, includeLibraryParam: false);
+
+        $actual = $builder->createSrcSet('image.jpg', ['w' => 540, 'q' => 75], ['disableVariableQuality' => false]);
         $expected =
-'https://demos.imgix.net/image.jpg?dpr=1&ixlib=php-'.UrlBuilder::VERSION.'&q=75&w=540 1x,
-https://demos.imgix.net/image.jpg?dpr=2&ixlib=php-'.UrlBuilder::VERSION.'&q=75&w=540 2x,
-https://demos.imgix.net/image.jpg?dpr=3&ixlib=php-'.UrlBuilder::VERSION.'&q=75&w=540 3x,
-https://demos.imgix.net/image.jpg?dpr=4&ixlib=php-'.UrlBuilder::VERSION.'&q=75&w=540 4x,
-https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-'.UrlBuilder::VERSION.'&q=75&w=540 5x';
+'https://demos.imgix.net/image.jpg?dpr=1&q=75&w=540 1x,
+https://demos.imgix.net/image.jpg?dpr=2&q=75&w=540 2x,
+https://demos.imgix.net/image.jpg?dpr=3&q=75&w=540 3x,
+https://demos.imgix.net/image.jpg?dpr=4&q=75&w=540 4x,
+https://demos.imgix.net/image.jpg?dpr=5&q=75&w=540 5x';
+
         $this->assertEquals($expected, $actual);
     }
 
     // Test that `q` overrides `disableVariableQuality = true`.
     public function testDprSrcsetQOverridesDisabledVariableQuality()
     {
-        $builder = new UrlBuilder('demos.imgix.net', true, false);
-        $opts = ['disableVariableQuality' => true]; // Disabled.
-        $actual = $builder->createSrcSet(
-            $path = 'image.jpg',
-            $params = ['w' => 440, 'q' => 99],
-            $options = $opts
-        );
+        $builder = new UrlBuilder(self::HOST, includeLibraryParam: false);
+
+        $actual = $builder->createSrcSet('image.jpg', ['w' => 440, 'q' => 99], ['disableVariableQuality' => true]);
         $expected =
-'https://demos.imgix.net/image.jpg?dpr=1&ixlib=php-'.UrlBuilder::VERSION.'&q=99&w=440 1x,
-https://demos.imgix.net/image.jpg?dpr=2&ixlib=php-'.UrlBuilder::VERSION.'&q=99&w=440 2x,
-https://demos.imgix.net/image.jpg?dpr=3&ixlib=php-'.UrlBuilder::VERSION.'&q=99&w=440 3x,
-https://demos.imgix.net/image.jpg?dpr=4&ixlib=php-'.UrlBuilder::VERSION.'&q=99&w=440 4x,
-https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-'.UrlBuilder::VERSION.'&q=99&w=440 5x';
+'https://demos.imgix.net/image.jpg?dpr=1&q=99&w=440 1x,
+https://demos.imgix.net/image.jpg?dpr=2&q=99&w=440 2x,
+https://demos.imgix.net/image.jpg?dpr=3&q=99&w=440 3x,
+https://demos.imgix.net/image.jpg?dpr=4&q=99&w=440 4x,
+https://demos.imgix.net/image.jpg?dpr=5&q=99&w=440 5x';
+
         $this->assertEquals($expected, $actual);
     }
 
     public function testCreateSrcSetFromWidthsArray()
     {
-        $builder = new UrlBuilder('demos.imgix.net', true, false);
-        $opts = ['widths' => [100, 200, 303, 404, 535]];
-        $actual = $builder->createSrcSet($path = 'image.jpg', $params = [], $options = $opts);
+        $builder = new UrlBuilder(self::HOST, includeLibraryParam: false);
+
+        $actual = $builder->createSrcSet('image.jpg', [], ['widths' => [100, 200, 303, 404, 535]]);
         $expected =
-'https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=100 100w,
-https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=200 200w,
-https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=303 303w,
-https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=404 404w,
-https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=535 535w';
+'https://demos.imgix.net/image.jpg?w=100 100w,
+https://demos.imgix.net/image.jpg?w=200 200w,
+https://demos.imgix.net/image.jpg?w=303 303w,
+https://demos.imgix.net/image.jpg?w=404 404w,
+https://demos.imgix.net/image.jpg?w=535 535w';
 
         $this->assertEquals($expected, $actual);
     }
@@ -436,8 +424,8 @@ https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=535 535w';
     public function testGivenHeightSrcsetGeneratesPairs()
     {
         $srcset = $this->srcsetBuilder(['h' => 300]);
-        $expectedNumberOfPairs = 5;
-        $this->assertEquals($expectedNumberOfPairs, count(explode(',', $srcset)));
+
+        $this->assertCount(5, explode(',', $srcset));
     }
 
     public function testGivenHeightRespectsParameter()
@@ -455,7 +443,7 @@ https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=535 535w';
         $srcset = $this->srcsetBuilder(['h' => 300]);
         $srclist = explode(',', $srcset);
 
-        foreach ($srclist as $i => $src) {
+        foreach ($srclist as $src) {
             $dpr = explode(' ', $src)[1];
             $this->assertMatchesRegularExpression('/x/', $dpr);
         }
@@ -466,7 +454,7 @@ https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=535 535w';
         $srcset = $this->srcsetBuilder(['h' => 300]);
         $srclist = explode(',', $srcset);
 
-        foreach ($srclist as $i => $src) {
+        foreach ($srclist as $src) {
             $dpr = explode(' ', $src)[0];
             $this->assertMatchesRegularExpression('/dpr=/', $dpr);
         }
@@ -477,9 +465,10 @@ https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=535 535w';
         $srcset = $this->srcsetBuilder(['h' => 300]);
         $srclist = explode(',', $srcset);
 
-        $srcs = array_map(function ($src) {
-            return explode(' ', $src)[0];
-        }, $srclist);
+        $srcs = array_map(
+            fn ($src) => explode(' ', $src)[0],
+            $srclist,
+        );
 
         foreach ($srcs as $src) {
             $this->assertMatchesRegularExpression('/s=/', $src);
@@ -542,8 +531,8 @@ https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=535 535w';
     public function testGivenAspectRatioSrcsetGeneratesPairs()
     {
         $srcset = $this->srcsetBuilder(['ar' => '3:2']);
-        $expectedNumberOfPairs = 31;
-        $this->assertEquals($expectedNumberOfPairs, count(explode(',', $srcset)));
+
+        $this->assertCount(31, explode(',', $srcset));
     }
 
     public function testGivenAspectRatioSrcsetPairsWithinBounds()
@@ -566,9 +555,10 @@ https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=535 535w';
         $srcset = $this->srcsetBuilder(['ar' => '3:2']);
         $srclist = explode(',', $srcset);
 
-        $widths = array_map(function ($src) {
-            return $this->parseWidth(explode(' ', $src)[1]);
-        }, $srclist);
+        $widths = array_map(
+            fn ($src) => $this->parseWidth(explode(' ', $src)[1]),
+            $srclist,
+        );
 
         $prev = $widths[0];
         $size = count($widths);
@@ -584,9 +574,10 @@ https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=535 535w';
         $srcset = $this->srcsetBuilder(['ar' => '3:2']);
         $srclist = explode(',', $srcset);
 
-        $srcs = array_map(function ($src) {
-            return explode(' ', $src)[0];
-        }, $srclist);
+        $srcs = array_map(
+            fn ($src) => explode(' ', $src)[0],
+            $srclist,
+        );
 
         foreach ($srcs as $src) {
             $this->assertMatchesRegularExpression('/s=/', $src);
@@ -644,5 +635,18 @@ https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=535 535w';
 
             $this->assertEquals($expectSignature, $generatedSignature);
         }
+    }
+
+    private function srcsetBuilder($params = [])
+    {
+        $builder = new UrlBuilder(self::HOST, true, 'my-key', false);
+
+        return $builder->createSrcSet('bridge.png', $params);
+    }
+
+    // parse the width as an int, eg "100w" => 100
+    private function parseWidth($width)
+    {
+        return (int) substr($width, 0, strlen($width) - 1);
     }
 }

--- a/tests/UrlBuilderTest.php
+++ b/tests/UrlBuilderTest.php
@@ -8,7 +8,6 @@ use PHPUnit\Framework\TestCase;
 
 class UrlBuilderTest extends TestCase
 {
-    public const PACKAGE_VERSION = '4.1.0';
     public const TARGET_WIDTHS = [
         100, 116, 135, 156, 181, 210, 244, 283,
         328, 380, 441, 512, 594, 689, 799, 927,
@@ -138,7 +137,7 @@ class UrlBuilderTest extends TestCase
         $builder = new UrlBuilder('demos.imgix.net', true);
         $url = $builder->createUrl('https://my-demo-site.com/files/133467012/avatar icon.png?some=chill&params=1');
 
-        $this->assertEquals('https://demos.imgix.net/https%3A%2F%2Fmy-demo-site.com%2Ffiles%2F133467012%2Favatar%20icon.png%3Fsome%3Dchill%26params%3D1?ixlib=php-'. self::PACKAGE_VERSION, $url);
+        $this->assertEquals('https://demos.imgix.net/https%3A%2F%2Fmy-demo-site.com%2Ffiles%2F133467012%2Favatar%20icon.png%3Fsome%3Dchill%26params%3D1?ixlib=php-'.UrlBuilder::VERSION, $url);
     }
 
     public function testNestedParameters()
@@ -239,10 +238,10 @@ class UrlBuilderTest extends TestCase
     public function testCustomSrcsetPairs()
     {
         // Test custom srcset pairs within ranges.
-        $expected = 'https://demos.imgix.net/image.jpg?ixlib=php-'. self::PACKAGE_VERSION . '&w=328 328w';
         $builder = new UrlBuilder('demos.imgix.net', true, false);
         $opts = ['start' => 328, 'stop' => 328];
         $actual = $builder->createSrcSet($path = 'image.jpg', $params = [], $options = $opts);
+        $expected = 'https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=328 328w';
         $this->assertEquals($expected, $actual);
 
         $builder = new UrlBuilder('demos.imgix.net', true, false);
@@ -251,15 +250,15 @@ class UrlBuilderTest extends TestCase
             $params = [],
             $options = ['start' => 720, 'stop' => 720]
         );
-        $expected = 'https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION . '&w=720 720w';
+        $expected = 'https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=720 720w';
         $this->assertEquals($expected, $actual);
 
         $builder = new UrlBuilder('demos.imgix.net', true, false);
         $opts = ['start' => 640, 'stop' => 720];
         $actual = $builder->createSrcSet($path = 'image.jpg', $params = [], $options = $opts);
         $expected = // Raw string literal
-'https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION .'&w=640 640w,
-https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION . '&w=720 720w';
+'https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=640 640w,
+https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=720 720w';
 
         $this->assertEquals($expected, $actual);
 
@@ -268,11 +267,11 @@ https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION . '&w=720 
         $opts = ['start' => 100, 'stop' => 108, 'tol' => 0.01];
         $actual = $builder->createSrcSet($path = 'image.jpg', $params = [], $options = $opts);
         $expected = // Raw string literal
-'https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION . '&w=100 100w,
-https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION . '&w=102 102w,
-https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION . '&w=104 104w,
-https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION . '&w=106 106w,
-https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION . '&w=108 108w';
+'https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=100 100w,
+https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=102 102w,
+https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=104 104w,
+https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=106 106w,
+https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=108 108w';
 
         $this->assertEquals($expected, $actual);
     }
@@ -322,11 +321,11 @@ https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION . '&w=108 
             $params = ['w' => 640, 'q' => 100]
         );
         $expected =
-'https://demos.imgix.net/image.jpg?dpr=1&ixlib=php-' . self::PACKAGE_VERSION .'&q=100&w=640 1x,
-https://demos.imgix.net/image.jpg?dpr=2&ixlib=php-' . self::PACKAGE_VERSION .'&q=100&w=640 2x,
-https://demos.imgix.net/image.jpg?dpr=3&ixlib=php-' . self::PACKAGE_VERSION .'&q=100&w=640 3x,
-https://demos.imgix.net/image.jpg?dpr=4&ixlib=php-' . self::PACKAGE_VERSION .'&q=100&w=640 4x,
-https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-' . self::PACKAGE_VERSION .'&q=100&w=640 5x';
+'https://demos.imgix.net/image.jpg?dpr=1&ixlib=php-'.UrlBuilder::VERSION.'&q=100&w=640 1x,
+https://demos.imgix.net/image.jpg?dpr=2&ixlib=php-'.UrlBuilder::VERSION.'&q=100&w=640 2x,
+https://demos.imgix.net/image.jpg?dpr=3&ixlib=php-'.UrlBuilder::VERSION.'&q=100&w=640 3x,
+https://demos.imgix.net/image.jpg?dpr=4&ixlib=php-'.UrlBuilder::VERSION.'&q=100&w=640 4x,
+https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-'.UrlBuilder::VERSION.'&q=100&w=640 5x';
         $this->assertEquals($expected, $actual);
     }
 
@@ -336,11 +335,11 @@ https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-' . self::PACKAGE_VERSION .'&q
         $builder = new UrlBuilder('demos.imgix.net', true, false);
         $actual = $builder->createSrcSet($path = 'image.jpg', $params = ['w' => 740]);
         $expected =
-'https://demos.imgix.net/image.jpg?dpr=1&ixlib=php-' . self::PACKAGE_VERSION . '&q=75&w=740 1x,
-https://demos.imgix.net/image.jpg?dpr=2&ixlib=php-' . self::PACKAGE_VERSION . '&q=50&w=740 2x,
-https://demos.imgix.net/image.jpg?dpr=3&ixlib=php-' . self::PACKAGE_VERSION . '&q=35&w=740 3x,
-https://demos.imgix.net/image.jpg?dpr=4&ixlib=php-' . self::PACKAGE_VERSION . '&q=23&w=740 4x,
-https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-' . self::PACKAGE_VERSION . '&q=20&w=740 5x';
+'https://demos.imgix.net/image.jpg?dpr=1&ixlib=php-'.UrlBuilder::VERSION.'&q=75&w=740 1x,
+https://demos.imgix.net/image.jpg?dpr=2&ixlib=php-'.UrlBuilder::VERSION.'&q=50&w=740 2x,
+https://demos.imgix.net/image.jpg?dpr=3&ixlib=php-'.UrlBuilder::VERSION.'&q=35&w=740 3x,
+https://demos.imgix.net/image.jpg?dpr=4&ixlib=php-'.UrlBuilder::VERSION.'&q=23&w=740 4x,
+https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-'.UrlBuilder::VERSION.'&q=20&w=740 5x';
         $this->assertEquals($expected, $actual);
     }
 
@@ -352,11 +351,11 @@ https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-' . self::PACKAGE_VERSION . '&
         $opts = ['disableVariableQuality' => true];
         $actual = $builder->createSrcSet($path = 'image.jpg', $params = $params, $opts = $opts);
         $expected =
-'https://demos.imgix.net/image.jpg?dpr=1&ixlib=php-' . self::PACKAGE_VERSION . '&w=640 1x,
-https://demos.imgix.net/image.jpg?dpr=2&ixlib=php-' . self::PACKAGE_VERSION . '&w=640 2x,
-https://demos.imgix.net/image.jpg?dpr=3&ixlib=php-' . self::PACKAGE_VERSION . '&w=640 3x,
-https://demos.imgix.net/image.jpg?dpr=4&ixlib=php-' . self::PACKAGE_VERSION . '&w=640 4x,
-https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-' . self::PACKAGE_VERSION . '&w=640 5x';
+'https://demos.imgix.net/image.jpg?dpr=1&ixlib=php-'.UrlBuilder::VERSION.'&w=640 1x,
+https://demos.imgix.net/image.jpg?dpr=2&ixlib=php-'.UrlBuilder::VERSION.'&w=640 2x,
+https://demos.imgix.net/image.jpg?dpr=3&ixlib=php-'.UrlBuilder::VERSION.'&w=640 3x,
+https://demos.imgix.net/image.jpg?dpr=4&ixlib=php-'.UrlBuilder::VERSION.'&w=640 4x,
+https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-'.UrlBuilder::VERSION.'&w=640 5x';
         $this->assertEquals($expected, $actual);
     }
 
@@ -369,11 +368,11 @@ https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-' . self::PACKAGE_VERSION . '&
         $opts = ['disableVariableQuality' => false]; // Enabled.
         $actual = $builder->createSrcSet($path = 'image.jpg', $params, $opts);
         $expected =
-'https://demos.imgix.net/image.jpg?dpr=1&ixlib=php-' . self::PACKAGE_VERSION . '&q=75&w=540 1x,
-https://demos.imgix.net/image.jpg?dpr=2&ixlib=php-' . self::PACKAGE_VERSION . '&q=75&w=540 2x,
-https://demos.imgix.net/image.jpg?dpr=3&ixlib=php-' . self::PACKAGE_VERSION . '&q=75&w=540 3x,
-https://demos.imgix.net/image.jpg?dpr=4&ixlib=php-' . self::PACKAGE_VERSION . '&q=75&w=540 4x,
-https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-' . self::PACKAGE_VERSION . '&q=75&w=540 5x';
+'https://demos.imgix.net/image.jpg?dpr=1&ixlib=php-'.UrlBuilder::VERSION.'&q=75&w=540 1x,
+https://demos.imgix.net/image.jpg?dpr=2&ixlib=php-'.UrlBuilder::VERSION.'&q=75&w=540 2x,
+https://demos.imgix.net/image.jpg?dpr=3&ixlib=php-'.UrlBuilder::VERSION.'&q=75&w=540 3x,
+https://demos.imgix.net/image.jpg?dpr=4&ixlib=php-'.UrlBuilder::VERSION.'&q=75&w=540 4x,
+https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-'.UrlBuilder::VERSION.'&q=75&w=540 5x';
         $this->assertEquals($expected, $actual);
     }
 
@@ -388,11 +387,11 @@ https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-' . self::PACKAGE_VERSION . '&
             $options = $opts
         );
         $expected =
-'https://demos.imgix.net/image.jpg?dpr=1&ixlib=php-' . self::PACKAGE_VERSION .'&q=99&w=440 1x,
-https://demos.imgix.net/image.jpg?dpr=2&ixlib=php-' . self::PACKAGE_VERSION .'&q=99&w=440 2x,
-https://demos.imgix.net/image.jpg?dpr=3&ixlib=php-' . self::PACKAGE_VERSION .'&q=99&w=440 3x,
-https://demos.imgix.net/image.jpg?dpr=4&ixlib=php-' . self::PACKAGE_VERSION .'&q=99&w=440 4x,
-https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-' . self::PACKAGE_VERSION .'&q=99&w=440 5x';
+'https://demos.imgix.net/image.jpg?dpr=1&ixlib=php-'.UrlBuilder::VERSION.'&q=99&w=440 1x,
+https://demos.imgix.net/image.jpg?dpr=2&ixlib=php-'.UrlBuilder::VERSION.'&q=99&w=440 2x,
+https://demos.imgix.net/image.jpg?dpr=3&ixlib=php-'.UrlBuilder::VERSION.'&q=99&w=440 3x,
+https://demos.imgix.net/image.jpg?dpr=4&ixlib=php-'.UrlBuilder::VERSION.'&q=99&w=440 4x,
+https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-'.UrlBuilder::VERSION.'&q=99&w=440 5x';
         $this->assertEquals($expected, $actual);
     }
 
@@ -402,11 +401,11 @@ https://demos.imgix.net/image.jpg?dpr=5&ixlib=php-' . self::PACKAGE_VERSION .'&q
         $opts = ['widths' => [100, 200, 303, 404, 535]];
         $actual = $builder->createSrcSet($path = 'image.jpg', $params = [], $options = $opts);
         $expected =
-'https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION .'&w=100 100w,
-https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION .'&w=200 200w,
-https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION .'&w=303 303w,
-https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION .'&w=404 404w,
-https://demos.imgix.net/image.jpg?ixlib=php-' . self::PACKAGE_VERSION .'&w=535 535w';
+'https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=100 100w,
+https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=200 200w,
+https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=303 303w,
+https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=404 404w,
+https://demos.imgix.net/image.jpg?ixlib=php-'.UrlBuilder::VERSION.'&w=535 535w';
 
         $this->assertEquals($expected, $actual);
     }

--- a/tests/UrlBuilderTest.php
+++ b/tests/UrlBuilderTest.php
@@ -137,7 +137,6 @@ class UrlBuilderTest extends TestCase
     {
         $builder = new UrlBuilder('demos.imgix.net', true);
         $url = $builder->createUrl('https://my-demo-site.com/files/133467012/avatar icon.png?some=chill&params=1');
-        // $composerFileJson = json_decode(file_get_contents('./composer.json'), true);
 
         $this->assertEquals('https://demos.imgix.net/https%3A%2F%2Fmy-demo-site.com%2Ffiles%2F133467012%2Favatar%20icon.png%3Fsome%3Dchill%26params%3D1?ixlib=php-'. self::PACKAGE_VERSION, $url);
     }

--- a/tests/UrlHelperTest.php
+++ b/tests/UrlHelperTest.php
@@ -18,8 +18,8 @@ class UrlHelperTest extends TestCase
 
     public function testHelperFormatPathWithSimplePath()
     {
-        $path = "dog.jpg";
-        $uh = new URLHelper("test.imgix.net", $path);
+        $path = 'dog.jpg';
+        $uh = new URLHelper('test.imgix.net', $path);
 
         $this->assertEquals($uh->formatPath($path), '/'.$path);
     }
@@ -146,19 +146,19 @@ class UrlHelperTest extends TestCase
 
     public function testHelperBuildSignedURLWithNullHashSetterParams()
     {
-        $uh = new URLHelper("imgix-library-secure-test-source.imgix.net", "dog.jpg", "https", "EHFQXiZhxP4wA2c4");
-        $uh->setParameter("w", 500);
-        $this->assertEquals("https://imgix-library-secure-test-source.imgix.net/dog.jpg?w=500&s=e4eb402d12bbdf267bf0fc5588170d56", $uh->getURL());
-        $uh->setParameter("w", null);
-        $this->assertEquals("https://imgix-library-secure-test-source.imgix.net/dog.jpg?s=2b0bc99b1042e3c1c9aae6598acc3def", $uh->getURL());
+        $uh = new URLHelper('imgix-library-secure-test-source.imgix.net', 'dog.jpg', 'https', 'EHFQXiZhxP4wA2c4');
+        $uh->setParameter('w', 500);
+        $this->assertEquals('https://imgix-library-secure-test-source.imgix.net/dog.jpg?w=500&s=e4eb402d12bbdf267bf0fc5588170d56', $uh->getURL());
+        $uh->setParameter('w', null);
+        $this->assertEquals('https://imgix-library-secure-test-source.imgix.net/dog.jpg?s=2b0bc99b1042e3c1c9aae6598acc3def', $uh->getURL());
     }
 
     public function testHelperBuildSignedURLWithHashDeleterParams()
     {
-        $uh = new URLHelper("imgix-library-secure-test-source.imgix.net", "dog.jpg", "https", "EHFQXiZhxP4wA2c4");
-        $uh->setParameter("w", 500);
-        $this->assertEquals("https://imgix-library-secure-test-source.imgix.net/dog.jpg?w=500&s=e4eb402d12bbdf267bf0fc5588170d56", $uh->getURL());
-        $uh->deleteParameter("w");
-        $this->assertEquals("https://imgix-library-secure-test-source.imgix.net/dog.jpg?s=2b0bc99b1042e3c1c9aae6598acc3def", $uh->getURL());
+        $uh = new URLHelper('imgix-library-secure-test-source.imgix.net', 'dog.jpg', 'https', 'EHFQXiZhxP4wA2c4');
+        $uh->setParameter('w', 500);
+        $this->assertEquals('https://imgix-library-secure-test-source.imgix.net/dog.jpg?w=500&s=e4eb402d12bbdf267bf0fc5588170d56', $uh->getURL());
+        $uh->deleteParameter('w');
+        $this->assertEquals('https://imgix-library-secure-test-source.imgix.net/dog.jpg?s=2b0bc99b1042e3c1c9aae6598acc3def', $uh->getURL());
     }
 }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -32,14 +32,14 @@ class ValidatorTest extends TestCase
 
     /**
      * Test `validateRange` throws if passed an invalid range,
-     * ie. if `BEGIN > END`.
+     * ie. if `START > STOP`.
      */
     public function testValidateRange()
     {
         $this->expectException(InvalidArgumentException::class);
-        $begin = 400;
-        $end = 100;
-        Validator::validateRange($begin, $end);
+        $start = 400;
+        $stop = 100;
+        Validator::validateRange($start, $stop);
     }
 
     /**


### PR DESCRIPTION
## Description

This is a rather large PR, with some tweaks to both the tests and source code. However, all tests are still passing with 100% coverage. There should be no breaking changes.

### General

- More code style formatting
- Rename and remove unnecessary variables
- Import `InvalidArgumentException` everywhere, to get rid of the leading `\`
- Reorder methods `setUseHttps()` and `setSignKey()` to match constructor order

### `UrlBuilder::VERSION` constant

I created a public constant on the main class, so it can be used for both the library param and for all tests. This removes the `$version` property, but since that was private it was only used withing the class.

### Constructor Promotion

In the constructor of both `UrlBuilder` and `UrlHelper` I've refactored to using [Constructor Promotion](https://www.php.net/manual/en/language.oop5.decon.php#language.oop5.decon.constructor.promotion). In simple words, it lets you declare the property directly in the constructor.

### Null Coalescing Operator

This is a shorter form for checking if a variable -- or a key in an array -- is set, and setting a fallback value if it's not. ([Docs](https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.null-coalesce-op))

```php
// Before
$widths = isset($options['widths']) ? $options['widths'] : null;

// After
$widths = $options['widths'] ?? null;
```

### Building srcsets

Earlier the srcsets were built directly using string concatenation. I've switched to building up an array of the individual strings and then gluing them together in the return.

I've switched from `for` loops to `foreach` loops, since they're generally easier to read (IMO).

Also, in `createDPRSrcSet`, I'm using the keys from `DPR_QUALITIES` instead of the separate `TARGET_RATIOS` which seems superfluous.

### README

I've updated the README to use the same formatting as the rest of the code. Also some of the examples were out of date with the actual results. I don't know if the test file for the README is needed, really? Easy to forget updating it when making changes.

### Tests

I've defined a `HOST` constant to ensure the tests call the same domain. Before it was both `demo.imgix.net` and `demos.imgix.net`.

Most tests now use [named arguments](https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments) to keep the default values for `useHttps` and `signKey`, and disabling the library param. Ex. `new UrlBuilder('demos.imgix.net', includeLibraryParam: false)`

`$params` and `$options` arrays has been inlined.

The library param has been disabled on many tests, where it wasn't needed. The reduces noise and makes it easier to se what is really being tested.

Some methods has been reordered in `UrlBuilderTest`.

## Checklist

- [x] Read the [contributing guidelines](CONTRIBUTING.md).
- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec format.
- [x] Update the readme.
- [x] All existing unit tests are still passing.
