### PR TITLE
config: update repo config files and documents

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
+* text=auto eol=lf
+
 .circleci/ export-ignore
 .github/ export-ignore
 .vscode/ export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+.circleci/ export-ignore
+.github/ export-ignore
+.vscode/ export-ignore
+tests/ export-ignore
+
+.editorconfig export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+CODE-OF-CONDUCT.md export-ignore
+CONTRIBUTING.md export-ignore
+phpunit.xml export-ignore
+pint.json export-ignore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for investing your time in contributing to this project! Please take a moment to review this document in order to streamline the contribution process for you and any reviewers involved.
 
-Read our [Code of Conduct](./CODE_OF_CONDUCT.md) to keep our community approachable and respectable.
+Read our [Code of Conduct](CODE-OF-CONDUCT.md) to keep our community approachable and respectable.
 
 In this guide you will get an overview of the contribution workflow from opening an issue, creating a PR, reviewing, and merging the PR.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,11 +56,9 @@ Commits should be in the format `<type>(<scope>): <description>`. This allows ou
 
 ### Example workflow
 
-Follow this process if you'd like your work considered for inclusion in the
-project:
+Follow this process if you'd like your work considered for inclusion in the project:
 
-1. [Fork](http://help.github.com/fork-a-repo/) the project, clone your fork,
-   and configure the remotes:
+1. [Fork](http://help.github.com/fork-a-repo/) the project, clone your fork, and configure the remotes:
 
    ```bash
    # Clone your fork of the repo into the current directory
@@ -78,16 +76,13 @@ project:
    git pull upstream <dev-branch>
    ```
 
-3. Create a new topic branch (off the main project development branch) to
-   contain your feature, change, or fix:
+3. Create a new topic branch (off the main project development branch) to contain your feature, change, or fix:
 
    ```bash
    git checkout -b <topic-branch-name>
    ```
 
-4. Commit your changes in logical chunks. Use Git's
-   [interactive rebase](https://help.github.com/articles/interactive-rebase)
-   feature to tidy up your commits before making them public.
+4. Commit your changes in logical chunks. Use Git's [interactive rebase](https://help.github.com/articles/interactive-rebase) feature to tidy up your commits before making them public.
 
 5. Locally merge (or rebase) the upstream development branch into your topic branch:
 
@@ -101,24 +96,22 @@ project:
    git push origin <topic-branch-name>
    ```
 
-7. [Open a Pull Request](https://help.github.com/articles/using-pull-requests/)
-   with a clear title and description.
+7. [Open a Pull Request](https://help.github.com/articles/using-pull-requests/) with a clear title and description.
 
-**IMPORTANT**: By submitting a patch, you agree to allow the project owner to
-license your work under the same license as that used by the project.
+**IMPORTANT**: By submitting a patch, you agree to allow the project owner to license your work under the same license as that used by the project.
 
-# Pre-requisites
+## Pre-requisites
 
 1. Check php is installed globally
 2. Install composer locally according to instructions here: https://getcomposer.org/download/
 
-# Install deps
+## Install deps
 
-Run `php composer.phar i` to install deps
+Run `php composer.phar install` to install deps
 
-# Development
+## Development
 
 Commands:
 
 - Run unit tests: `./vendor/bin/phpunit`
-- Update dependencies: `php composer.phar u`
+- Update dependencies: `php composer.phar update`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,5 +113,5 @@ Run `php composer.phar install` to install deps
 
 Commands:
 
-- Run unit tests: `./vendor/bin/phpunit`
+- Run unit tests: `php composer.phar run test`
 - Update dependencies: `php composer.phar update`

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "imgix/imgix-php",
     "description": "A PHP client library for generating URLs with imgix.",
     "type": "library",
-    "version": "4.1.0",
     "keywords": [
         "imgix"
     ],

--- a/composer.json
+++ b/composer.json
@@ -1,27 +1,27 @@
 {
-  "name": "imgix/imgix-php",
-  "description": "A PHP client library for generating URLs with imgix.",
-  "type": "library",
-  "version": "4.1.0",
-  "license": "BSD-2-Clause",
-  "keywords": [
-    "imgix"
-  ],
-  "require": {
-    "php": "^8.0"
-  },
-  "require-dev": {
-    "laravel/pint": "^1.4",
-    "phpunit/phpunit": "^9.5.10"
-  },
-  "autoload": {
-    "psr-4": {
-      "Imgix\\": "src/"
+    "name": "imgix/imgix-php",
+    "description": "A PHP client library for generating URLs with imgix.",
+    "type": "library",
+    "version": "4.1.0",
+    "license": "BSD-2-Clause",
+    "keywords": [
+        "imgix"
+    ],
+    "require": {
+        "php": "^8.0"
+    },
+    "require-dev": {
+        "laravel/pint": "^1.4",
+        "phpunit/phpunit": "^9.5.10"
+    },
+    "autoload": {
+        "psr-4": {
+            "Imgix\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Imgix\\Tests\\": "tests/"
+        }
     }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Imgix\\Tests\\": "tests/"
-    }
-  }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,11 @@
             "Imgix\\Tests\\": "tests/"
         }
     },
+    "scripts": {
+        "format": "vendor/bin/pint",
+        "test": "vendor/bin/phpunit",
+        "test-coverage": "@test --coverage-text"
+    },
     "config": {
         "sort-packages": true
     },

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,10 @@
     "description": "A PHP client library for generating URLs with imgix.",
     "type": "library",
     "version": "4.1.0",
-    "license": "BSD-2-Clause",
     "keywords": [
         "imgix"
     ],
+    "license": "BSD-2-Clause",
     "require": {
         "php": "^8.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,11 @@
         "imgix"
     ],
     "license": "BSD-2-Clause",
+    "homepage": "https://docs.imgix.com",
+    "support": {
+        "issues": "https://github.com/imgix/imgix-php/issues",
+        "source": "https://github.com/imgix/imgix-php"
+    },
     "require": {
         "php": "^8.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,10 @@
         "psr-4": {
             "Imgix\\Tests\\": "tests/"
         }
-    }
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3ccda72ca21e42c2d3b05dc5beadc568",
+    "content-hash": "601521759d44cd966079671d17852a44",
     "packages": [],
     "packages-dev": [
         {
@@ -79,16 +79,16 @@
         },
         {
             "name": "laravel/pint",
-            "version": "v1.4.0",
+            "version": "v1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "0e7ffdb0af871be10d798e234772ea5d4020ae4a"
+                "reference": "80ddf23a5d97825e79bb1018eebb6f3f985d4fa8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/0e7ffdb0af871be10d798e234772ea5d4020ae4a",
-                "reference": "0e7ffdb0af871be10d798e234772ea5d4020ae4a",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/80ddf23a5d97825e79bb1018eebb6f3f985d4fa8",
+                "reference": "80ddf23a5d97825e79bb1018eebb6f3f985d4fa8",
                 "shasum": ""
             },
             "require": {
@@ -99,7 +99,7 @@
                 "php": "^8.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "~3.13.1",
+                "friendsofphp/php-cs-fixer": "^3.14",
                 "illuminate/view": "^9.32.0",
                 "laravel-zero/framework": "^9.2.0",
                 "mockery/mockery": "^1.5.1",
@@ -141,7 +141,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2023-01-10T20:03:42+00:00"
+            "time": "2023-01-31T15:50:45+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -371,16 +371,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.23",
+            "version": "9.2.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "9f1f0f9a2fbb680b26d1cf9b61b6eac43a6e4e9c"
+                "reference": "2cf940ebc6355a9d430462811b5aaa308b174bed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/9f1f0f9a2fbb680b26d1cf9b61b6eac43a6e4e9c",
-                "reference": "9f1f0f9a2fbb680b26d1cf9b61b6eac43a6e4e9c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2cf940ebc6355a9d430462811b5aaa308b174bed",
+                "reference": "2cf940ebc6355a9d430462811b5aaa308b174bed",
                 "shasum": ""
             },
             "require": {
@@ -436,7 +436,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.23"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.24"
             },
             "funding": [
                 {
@@ -444,7 +444,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-28T12:41:10+00:00"
+            "time": "2023-01-26T08:26:55+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1805,9 +1805,9 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "stability-flags": [],
-    "prefer-stable": false,
+    "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.0"

--- a/pint.json
+++ b/pint.json
@@ -1,3 +1,3 @@
 {
-    "preset": "psr12"
+    "preset": "laravel"
 }


### PR DESCRIPTION
## Description

### .editorconfig

Helps contributors by making sure their editor is behaving according to our specifications.
[More info](https://editorconfig.org)

### .gitattributes

Ignores repo files and tests when exporting this project. For example, when downloading as .zip or when installing via composer. This helps save a few hundred kilobytes for every install.

**Examples from other popular PHP projects:**

- [Laravel Framework](https://github.com/laravel/framework/blob/9.x/.gitattributes)
- [Spatie PHP Package Skeleton](https://github.com/spatie/package-skeleton-php/blob/main/.gitattributes)

### composer.json

Remove `version` field. This is handled automatically by [packagist.org](https://packagist.org/packages/imgix/imgix-php) with the branches/tags/releases in this repo. This way, you only need to update the version numer in _one_ place for each new release; the constant `UrlBuilder::VERSION`.

> The easiest way to manage versioning is to just omit the version field from the composer.json file. The version numbers will then be parsed from the tag and branch names.
> [Source](https://packagist.org/about#managing-package-versions)

**Other changes:**

- Use 4 spaces indentation instead of 2
- Reorder some fields
- Add useful links to documentation and repository
- Add custom scripts for formatting and testing
- Add common config values, see [laravel-framework](https://github.com/laravel/framework/blob/c39ec481f25ba96f3686f736f01d0181c09e834c/composer.json#L176-L183) and [package-skeleton](https://github.com/spatie/package-skeleton-php/blob/16331fffd1c83d2453822c1ec30cad39f1bcc492/composer.json#L39-L47)
- Update dependencies and commit `composer.lock` (Related issue #113)

### CONTRIBUTING.md

Mostly formatting, fixing a broken link to Code of Conduct and clarifying the composer commands at the bottom. Also using the newly added composer custom script for running the tests.

### pint.json

Update preset from `psr12` to `laravel`. The `laravel` preset is based on `psr12` with some other quality of life improvements. Formatting the code in its current state has no difference between the presets. 

Another preset available is `symfony`. I don't like that one personally. Mostly because it uses "Yoda style" conditions. Ex: `if ($meaning === 42)` becomes `if (42 === $meaning)`.

- [List of rules in Laravel preset](https://github.com/laravel/pint/blob/main/resources/presets/laravel.php)
- [List of available rules](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/rules/index.rst)

## Checklist

- [x] Read the [contributing guidelines](CONTRIBUTING.md).
- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec format.
- [x] Update the readme.
- [x] All existing unit tests are still passing.
